### PR TITLE
More powerful NFT Attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,19 @@ See the [documentation](docs/Freeport.md) (regenerate with `npm run doc`).
 
 ## Releases
 
+### 2022-01-07: Extended NFT Attachments
+
+NFT Attachments now support variable-sized attachment data, and separate events for minter, owner, and anonymous senders. This is included in the deployment 2021-12-31 below.
+
 ### 2021-12-31: ERC20 Adapter
 
 Use an ERC20 adapter instead of a Polygon bridge adapter.
-Commit 66661145 deployed.
+Commit caefd460 deployed.
 
 #### Mainnet
 
 Contracts: [Freeport](https://polygonscan.com/address/0x521296be238B164b9A391b6F6175741826CB5F33) and
-[Fiat Gateway](https://polygonscan.com/address/0xf6d782Cd0dC9976170242B94C8E653C7bA489634) and [Simple Auction](https://polygonscan.com/address/0xd26d11faceA9798B3be6C8a42803eb31204DA790) and [NFT Attachment](https://polygonscan.com/address/0x147595af3de969a64f3Fb8A3ACC505325EBE1334) and [Forwarder](https://polygonscan.com/address/0x5e43bA1666B13C346E2ECdeD9dcDaaf02fbb0B22) and [Bypass Forwarder](https://polygonscan.com/address/0x1E77956B211cb4437317CF692141b292B1433f29).
+[Fiat Gateway](https://polygonscan.com/address/0xf6d782Cd0dC9976170242B94C8E653C7bA489634) and [Simple Auction](https://polygonscan.com/address/0xd26d11faceA9798B3be6C8a42803eb31204DA790) and [NFT Attachment](https://polygonscan.com/address/0x5E376313fddBE3010F5d9fbC446C63d803590445) and [Forwarder](https://polygonscan.com/address/0x5e43bA1666B13C346E2ECdeD9dcDaaf02fbb0B22) and [Bypass Forwarder](https://polygonscan.com/address/0x1E77956B211cb4437317CF692141b292B1433f29).
 
 Accounts:
 No ERC20 connection yet.
@@ -30,7 +34,7 @@ No Meta-tx Relayer Account yet.
 #### Stage
 
 Contracts: [Freeport](https://mumbai.polygonscan.com/address/0x8bD1D3a93C7FB1786fFE3d0610987C3879287698) and
-[Fiat Gateway](https://mumbai.polygonscan.com/address/0x1C59A68ff017f14D1a8B80644F25F047b1CC58C5) and [Simple Auction](https://mumbai.polygonscan.com/address/0x8fD690fFf020547e9Ca027Bf96F7B3A084Be485B) and [NFT Attachment](https://mumbai.polygonscan.com/address/0x2d16772036e7FA7D752b075b6b559A8bE57B8cCe) and [Forwarder](https://mumbai.polygonscan.com/address/0x03988B5eaf8EFC804320B860dBb7f281EdF92420) and [Bypass Forwarder](https://mumbai.polygonscan.com/address/0x7a770bf5a93a3a686FA2B40cA399462ceD10725D) and [TestERC20](https://mumbai.polygonscan.com/address/0x93E73E25F290f8A50281A801109f75CB4E8e3233).
+[Fiat Gateway](https://mumbai.polygonscan.com/address/0x1C59A68ff017f14D1a8B80644F25F047b1CC58C5) and [Simple Auction](https://mumbai.polygonscan.com/address/0x8fD690fFf020547e9Ca027Bf96F7B3A084Be485B) and [NFT Attachment](https://mumbai.polygonscan.com/address/0x64fe48A0555b3b822E5DAC8347DFD1FDc9A2E91D) and [Forwarder](https://mumbai.polygonscan.com/address/0x03988B5eaf8EFC804320B860dBb7f281EdF92420) and [Bypass Forwarder](https://mumbai.polygonscan.com/address/0x7a770bf5a93a3a686FA2B40cA399462ceD10725D) and [TestERC20](https://mumbai.polygonscan.com/address/0x93E73E25F290f8A50281A801109f75CB4E8e3233).
 
 Accounts:
 [Fiat-to-NFT Service](https://mumbai.polygonscan.com/address/0x53B53189e668dC2ee3bA7A44Bb033E60F400d395) (
@@ -42,7 +46,7 @@ No Meta-tx Relayer Account yet.
 #### Dev
 
 Contracts: [Freeport](https://mumbai.polygonscan.com/address/0xC59Af7FbE4553e07aA668C1A13CAa78Cd4550579) and
-[Fiat Gateway](https://mumbai.polygonscan.com/address/0xE8949692827C3034c6fF185a38c192ca3059f6e5) and [Simple Auction](https://mumbai.polygonscan.com/address/0x8B05131559a510f60f0A496B4428D449390A3f00) and [NFT Attachment](https://mumbai.polygonscan.com/address/0x2e8538913dEF3abAC5c4fCFAD7F40722A19099Ee) and [Forwarder](https://mumbai.polygonscan.com/address/0x2d7FCbBfe773c5E7C7fccbA8434386048267c16D) and [Bypass Forwarder](https://mumbai.polygonscan.com/address/0xF7544C67e382230B2732C8360BfAEeAE840C8b1e) and [TestERC20](https://mumbai.polygonscan.com/address/0x4e5a86E128f8Fb652169f6652e2Cd17aAe409e96).
+[Fiat Gateway](https://mumbai.polygonscan.com/address/0xE8949692827C3034c6fF185a38c192ca3059f6e5) and [Simple Auction](https://mumbai.polygonscan.com/address/0x8B05131559a510f60f0A496B4428D449390A3f00) and [NFT Attachment](https://mumbai.polygonscan.com/address/0x5d0a9933D779265B67429147184261eB7163370b) and [Forwarder](https://mumbai.polygonscan.com/address/0x2d7FCbBfe773c5E7C7fccbA8434386048267c16D) and [Bypass Forwarder](https://mumbai.polygonscan.com/address/0xF7544C67e382230B2732C8360BfAEeAE840C8b1e) and [TestERC20](https://mumbai.polygonscan.com/address/0x4e5a86E128f8Fb652169f6652e2Cd17aAe409e96).
 
 Accounts:
 [Fiat-to-NFT Service](https://mumbai.polygonscan.com/address/0xD2B94CBF0fFAA9bc07126ab53f980Cd95a5Ed243) (

--- a/build/contracts/NFTAttachment.json
+++ b/build/contracts/NFTAttachment.json
@@ -4,8 +4,8 @@
     {
       "inputs": [
         {
-          "internalType": "address",
-          "name": "_nftContract",
+          "internalType": "contract Freeport",
+          "name": "_freeport",
           "type": "address"
         }
       ],
@@ -18,7 +18,7 @@
         {
           "indexed": true,
           "internalType": "address",
-          "name": "sender",
+          "name": "anonym",
           "type": "address"
         },
         {
@@ -29,12 +29,62 @@
         },
         {
           "indexed": false,
-          "internalType": "bytes32",
-          "name": "cid",
-          "type": "bytes32"
+          "internalType": "bytes",
+          "name": "attachment",
+          "type": "bytes"
         }
       ],
-      "name": "AttachToNFT",
+      "name": "AnonymAttachToNFT",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "minter",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "nftId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes",
+          "name": "attachment",
+          "type": "bytes"
+        }
+      ],
+      "name": "MinterAttachToNFT",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "nftId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes",
+          "name": "attachment",
+          "type": "bytes"
+        }
+      ],
+      "name": "OwnerAttachToNFT",
       "type": "event"
     },
     {
@@ -141,6 +191,20 @@
       "constant": true
     },
     {
+      "inputs": [],
+      "name": "freeport",
+      "outputs": [
+        {
+          "internalType": "contract Freeport",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function",
+      "constant": true
+    },
+    {
       "inputs": [
         {
           "internalType": "bytes32",
@@ -224,20 +288,6 @@
       "constant": true
     },
     {
-      "inputs": [],
-      "name": "nftContract",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function",
-      "constant": true
-    },
-    {
       "inputs": [
         {
           "internalType": "bytes32",
@@ -301,26 +351,82 @@
           "type": "uint256"
         },
         {
-          "internalType": "bytes32",
-          "name": "cid",
-          "type": "bytes32"
+          "internalType": "bytes",
+          "name": "attachment",
+          "type": "bytes"
         }
       ],
-      "name": "attachToNFT",
+      "name": "minterAttachToNFT",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "nftId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "attachment",
+          "type": "bytes"
+        }
+      ],
+      "name": "ownerAttachToNFT",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "nftId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "attachment",
+          "type": "bytes"
+        }
+      ],
+      "name": "anonymAttachToNFT",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "id",
+          "type": "uint256"
+        }
+      ],
+      "name": "_minterFromNftId",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "minter",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function",
+      "constant": true
     }
   ],
-  "metadata": "{\"compiler\":{\"version\":\"0.8.4+commit.c7e474f2\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_nftContract\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nftId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"cid\",\"type\":\"bytes32\"}],\"name\":\"AttachToNFT\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"previousAdminRole\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"newAdminRole\",\"type\":\"bytes32\"}],\"name\":\"RoleAdminChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"RoleGranted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"RoleRevoked\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"DEFAULT_ADMIN_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"META_TX_FORWARDER\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nftId\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"cid\",\"type\":\"bytes32\"}],\"name\":\"attachToNFT\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"}],\"name\":\"getRoleAdmin\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"grantRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"hasRole\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"forwarder\",\"type\":\"address\"}],\"name\":\"isTrustedForwarder\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"nftContract\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"renounceRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"revokeRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{\"getRoleAdmin(bytes32)\":{\"details\":\"Returns the admin role that controls `role`. See {grantRole} and {revokeRole}. To change a role's admin, use {_setRoleAdmin}.\"},\"grantRole(bytes32,address)\":{\"details\":\"Grants `role` to `account`. If `account` had not been already granted `role`, emits a {RoleGranted} event. Requirements: - the caller must have ``role``'s admin role.\"},\"hasRole(bytes32,address)\":{\"details\":\"Returns `true` if `account` has been granted `role`.\"},\"renounceRole(bytes32,address)\":{\"details\":\"Revokes `role` from the calling account. Roles are often managed via {grantRole} and {revokeRole}: this function's purpose is to provide a mechanism for accounts to lose their privileges if they are compromised (such as when a trusted device is misplaced). If the calling account had been granted `role`, emits a {RoleRevoked} event. Requirements: - the caller must be `account`.\"},\"revokeRole(bytes32,address)\":{\"details\":\"Revokes `role` from `account`. If `account` had been granted `role`, emits a {RoleRevoked} event. Requirements: - the caller must have ``role``'s admin role.\"},\"supportsInterface(bytes4)\":{\"details\":\"See {IERC165-supportsInterface}.\"}},\"version\":1},\"userdoc\":{\"events\":{\"AttachToNFT(address,uint256,bytes32)\":{\"notice\":\"The account `sender` wished to attach an object identified by `cid` to the NFT type `nftId`. There is absolutely no validation. It is the responsibility of the reader of this event to decide who the sender is and what the object means.\"}},\"kind\":\"user\",\"methods\":{\"attachToNFT(uint256,bytes32)\":{\"notice\":\"Attach an object identified by `cid` to the NFT type `nftId`. There is absolutely no validation. It is the responsibility of the reader of this event to decide who the sender is and what the object means.\"},\"constructor\":{\"notice\":\"Set which NFT contract to refer to.\"},\"nftContract()\":{\"notice\":\"This attachment contract refers to the NFT contract in this variable. This is informative, there is no validation.\"}},\"notice\":\"The contract NFTAttachment allows users to attach objects to NFTs. Some application can listen for the events and interpret the objects in some way. Anyone can attach objects to any NFT. It is the responsibility of the app to interpret who the sender is and what the object means. An object is identified by CID, a.k.a. Content Identifier or IPFS file, of maximum 32 bytes. The content may be retrieved from Cere DDC or some other store.\",\"version\":1}},\"settings\":{\"compilationTarget\":{\"project:/contracts/NFTAttachment.sol\":\"NFTAttachment\"},\"evmVersion\":\"istanbul\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":10},\"remappings\":[]},\"sources\":{\"project:/contracts/NFTAttachment.sol\":{\"keccak256\":\"0xb89178ad1d9e35df23695f0c3cbd859d32716e9ae31a60a02e38765ca7d559c2\",\"urls\":[\"bzz-raw://ef54b681b422874e76582aa917038144b81c66e45336014fa0c72058fa55001a\",\"dweb:/ipfs/QmNtYkMVWym4RnN9bGyCjN2yRq5pCtQNnjkFGAXJ2ph8wu\"]},\"project:/contracts/access/AccessControl.sol\":{\"keccak256\":\"0x98fac37221212c8f126f198d262a4df86394bd1a9969f61e40739fe8ac013dd8\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://62f98a3c51ff54e1d19c8845da55415c85b4f28c81c0c3b1361eb6eaa905a0c6\",\"dweb:/ipfs/QmTZxiScs2HXZRtscWGjBBXmG4qeFGk1Bq8FGzhbWi1wr3\"]},\"project:/contracts/freeportParts/MetaTxContext.sol\":{\"keccak256\":\"0x12579308ed77228d87aad495399c8feff27642efa9aae8fe2fd2049da4140459\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://568cafead94d0ecbee30203822e404d1bf53653257f933db70b6a035223189dd\",\"dweb:/ipfs/QmWmgcDLWNeswQF5WGM4zXpdaXcA4sQdWZbGvfSLEZWF2K\"]},\"project:/contracts/utils/Context.sol\":{\"keccak256\":\"0xf930d2df426bfcfc1f7415be724f04081c96f4fb9ec8d0e3a521c07692dface0\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://fc2bfdea0d2562c76fb3c4cf70a86c6ba25c5a30e8f8515c95aafdf8383f8395\",\"dweb:/ipfs/QmTbFya18786ckJfLYUoWau9jBTKfmWnWm5XSViWvB7PXN\"]},\"project:/contracts/utils/Strings.sol\":{\"keccak256\":\"0x456e9b3a2bfe189b5249857f624f4139e59331db518483b456c4e587a20552e0\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://1123c9545decc48a011370ebab4bf53dda98524fa21f9498e68851ba8f0ffc0f\",\"dweb:/ipfs/QmUpgMg8EFDnv87ePKUjXxXpJT3qwHRj9VDNSnRxu7T9sy\"]},\"project:/contracts/utils/introspection/ERC165.sol\":{\"keccak256\":\"0x5718c5df9bd67ac68a796961df938821bb5dc0cd4c6118d77e9145afb187409b\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://d10e1d9b26042424789246603906ad06143bf9a928f4e99de8b5e3bdc662f549\",\"dweb:/ipfs/Qmejonoaj5MLekPus229rJQHcC6E9dz2xorjHJR84fMfmn\"]},\"project:/contracts/utils/introspection/IERC165.sol\":{\"keccak256\":\"0xa28007762d9da9db878dd421960c8cb9a10471f47ab5c1b3309bfe48e9e79ff4\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://796ab6e88af7bf0e78def0f059310c903af6a312b565344e0ff524a0f26e81c6\",\"dweb:/ipfs/QmcsVgLgzWdor3UnAztUkXKNGcysm1MPneWksF72AvnwBx\"]}},\"version\":1}",
-  "bytecode": "0x608060405234801561001057600080fd5b506040516109b33803806109b383398101604081905261002f91610054565b600180546001600160a01b0319166001600160a01b0392909216919091179055610082565b600060208284031215610065578081fd5b81516001600160a01b038116811461007b578182fd5b9392505050565b610922806100916000396000f3fe608060405234801561001057600080fd5b50600436106100995760003560e01c806301ffc9a71461009e578063248a9ca3146100c65780632f2ff15d146100e757806336568abe146100fc578063572b6c051461010f57806391d14854146101225780639a86e8ce14610135578063a217fddf1461014a578063ab278d1914610152578063d547741f14610165578063d56d229d14610178575b600080fd5b6100b16100ac36600461074d565b6101a3565b60405190151581526020015b60405180910390f35b6100d96100d436600461070a565b6101da565b6040519081526020016100bd565b6100fa6100f5366004610722565b6101ef565b005b6100fa61010a366004610722565b610218565b6100b161011d3660046106f0565b6102ab565b6100b1610130366004610722565b6102c1565b6100d96000805160206108cd83398151915281565b6100d9600081565b6100fa610160366004610775565b6102ea565b6100fa610173366004610722565b61033f565b60015461018b906001600160a01b031681565b6040516001600160a01b0390911681526020016100bd565b60006001600160e01b03198216637965db0b60e01b14806101d457506301ffc9a760e01b6001600160e01b03198316145b92915050565b60009081526020819052604090206001015490565b6101f8826101da565b6102098161020461035e565b610380565b61021383836103e4565b505050565b61022061035e565b6001600160a01b0316816001600160a01b03161461029d5760405162461bcd60e51b815260206004820152602f60248201527f416363657373436f6e74726f6c3a2063616e206f6e6c792072656e6f756e636560448201526e103937b632b9903337b91039b2b63360891b60648201526084015b60405180910390fd5b6102a78282610469565b5050565b60006101d46000805160206108cd833981519152835b6000918252602082815260408084206001600160a01b0393909316845291905290205460ff1690565b60006102f461035e565b905082816001600160a01b03167fcb0dbc631188ff7e4c5831ec907b2d9ca2786dd0314af3e43a7269821a19e2b48460405161033291815260200190565b60405180910390a3505050565b610348826101da565b6103548161020461035e565b6102138383610469565b6000610369336102ab565b1561037b575060131936013560601c90565b503390565b61038a82826102c1565b6102a7576103a2816001600160a01b031660146104ec565b6103ad8360206104ec565b6040516020016103be929190610796565b60408051601f198184030181529082905262461bcd60e51b825261029491600401610805565b6103ee82826102c1565b6102a7576000828152602081815260408083206001600160a01b03851684529091529020805460ff1916600117905561042561035e565b6001600160a01b0316816001600160a01b0316837f2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d60405160405180910390a45050565b61047382826102c1565b156102a7576000828152602081815260408083206001600160a01b03851684529091529020805460ff191690556104a861035e565b6001600160a01b0316816001600160a01b0316837ff6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b60405160405180910390a45050565b606060006104fb836002610850565b610506906002610838565b6001600160401b0381111561052b57634e487b7160e01b600052604160045260246000fd5b6040519080825280601f01601f191660200182016040528015610555576020820181803683370190505b509050600360fc1b8160008151811061057e57634e487b7160e01b600052603260045260246000fd5b60200101906001600160f81b031916908160001a905350600f60fb1b816001815181106105bb57634e487b7160e01b600052603260045260246000fd5b60200101906001600160f81b031916908160001a90535060006105df846002610850565b6105ea906001610838565b90505b600181111561067e576f181899199a1a9b1b9c1cb0b131b232b360811b85600f166010811061062c57634e487b7160e01b600052603260045260246000fd5b1a60f81b82828151811061065057634e487b7160e01b600052603260045260246000fd5b60200101906001600160f81b031916908160001a90535060049490941c936106778161089f565b90506105ed565b5083156106cd5760405162461bcd60e51b815260206004820181905260248201527f537472696e67733a20686578206c656e67746820696e73756666696369656e746044820152606401610294565b9392505050565b80356001600160a01b03811681146106eb57600080fd5b919050565b600060208284031215610701578081fd5b6106cd826106d4565b60006020828403121561071b578081fd5b5035919050565b60008060408385031215610734578081fd5b82359150610744602084016106d4565b90509250929050565b60006020828403121561075e578081fd5b81356001600160e01b0319811681146106cd578182fd5b60008060408385031215610787578182fd5b50508035926020909101359150565b76020b1b1b2b9b9a1b7b73a3937b61d1030b1b1b7bab73a1604d1b8152600083516107c881601785016020880161086f565b7001034b99036b4b9b9b4b733903937b6329607d1b60179184019182015283516107f981602884016020880161086f565b01602801949350505050565b602081526000825180602084015261082481604085016020870161086f565b601f01601f19169190910160400192915050565b6000821982111561084b5761084b6108b6565b500190565b600081600019048311821515161561086a5761086a6108b6565b500290565b60005b8381101561088a578181015183820152602001610872565b83811115610899576000848401525b50505050565b6000816108ae576108ae6108b6565b506000190190565b634e487b7160e01b600052601160045260246000fdfe3d2e894c222ba979e2dce2c7d940c0e9bb14306669e9f034eb1bb3979a2069d8a2646970667358221220f3b13b7b58bdbe743297cfa71d680361ad9cd75d6becf3db178aeada4e31c75164736f6c63430008040033",
-  "deployedBytecode": "0x608060405234801561001057600080fd5b50600436106100995760003560e01c806301ffc9a71461009e578063248a9ca3146100c65780632f2ff15d146100e757806336568abe146100fc578063572b6c051461010f57806391d14854146101225780639a86e8ce14610135578063a217fddf1461014a578063ab278d1914610152578063d547741f14610165578063d56d229d14610178575b600080fd5b6100b16100ac36600461074d565b6101a3565b60405190151581526020015b60405180910390f35b6100d96100d436600461070a565b6101da565b6040519081526020016100bd565b6100fa6100f5366004610722565b6101ef565b005b6100fa61010a366004610722565b610218565b6100b161011d3660046106f0565b6102ab565b6100b1610130366004610722565b6102c1565b6100d96000805160206108cd83398151915281565b6100d9600081565b6100fa610160366004610775565b6102ea565b6100fa610173366004610722565b61033f565b60015461018b906001600160a01b031681565b6040516001600160a01b0390911681526020016100bd565b60006001600160e01b03198216637965db0b60e01b14806101d457506301ffc9a760e01b6001600160e01b03198316145b92915050565b60009081526020819052604090206001015490565b6101f8826101da565b6102098161020461035e565b610380565b61021383836103e4565b505050565b61022061035e565b6001600160a01b0316816001600160a01b03161461029d5760405162461bcd60e51b815260206004820152602f60248201527f416363657373436f6e74726f6c3a2063616e206f6e6c792072656e6f756e636560448201526e103937b632b9903337b91039b2b63360891b60648201526084015b60405180910390fd5b6102a78282610469565b5050565b60006101d46000805160206108cd833981519152835b6000918252602082815260408084206001600160a01b0393909316845291905290205460ff1690565b60006102f461035e565b905082816001600160a01b03167fcb0dbc631188ff7e4c5831ec907b2d9ca2786dd0314af3e43a7269821a19e2b48460405161033291815260200190565b60405180910390a3505050565b610348826101da565b6103548161020461035e565b6102138383610469565b6000610369336102ab565b1561037b575060131936013560601c90565b503390565b61038a82826102c1565b6102a7576103a2816001600160a01b031660146104ec565b6103ad8360206104ec565b6040516020016103be929190610796565b60408051601f198184030181529082905262461bcd60e51b825261029491600401610805565b6103ee82826102c1565b6102a7576000828152602081815260408083206001600160a01b03851684529091529020805460ff1916600117905561042561035e565b6001600160a01b0316816001600160a01b0316837f2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d60405160405180910390a45050565b61047382826102c1565b156102a7576000828152602081815260408083206001600160a01b03851684529091529020805460ff191690556104a861035e565b6001600160a01b0316816001600160a01b0316837ff6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b60405160405180910390a45050565b606060006104fb836002610850565b610506906002610838565b6001600160401b0381111561052b57634e487b7160e01b600052604160045260246000fd5b6040519080825280601f01601f191660200182016040528015610555576020820181803683370190505b509050600360fc1b8160008151811061057e57634e487b7160e01b600052603260045260246000fd5b60200101906001600160f81b031916908160001a905350600f60fb1b816001815181106105bb57634e487b7160e01b600052603260045260246000fd5b60200101906001600160f81b031916908160001a90535060006105df846002610850565b6105ea906001610838565b90505b600181111561067e576f181899199a1a9b1b9c1cb0b131b232b360811b85600f166010811061062c57634e487b7160e01b600052603260045260246000fd5b1a60f81b82828151811061065057634e487b7160e01b600052603260045260246000fd5b60200101906001600160f81b031916908160001a90535060049490941c936106778161089f565b90506105ed565b5083156106cd5760405162461bcd60e51b815260206004820181905260248201527f537472696e67733a20686578206c656e67746820696e73756666696369656e746044820152606401610294565b9392505050565b80356001600160a01b03811681146106eb57600080fd5b919050565b600060208284031215610701578081fd5b6106cd826106d4565b60006020828403121561071b578081fd5b5035919050565b60008060408385031215610734578081fd5b82359150610744602084016106d4565b90509250929050565b60006020828403121561075e578081fd5b81356001600160e01b0319811681146106cd578182fd5b60008060408385031215610787578182fd5b50508035926020909101359150565b76020b1b1b2b9b9a1b7b73a3937b61d1030b1b1b7bab73a1604d1b8152600083516107c881601785016020880161086f565b7001034b99036b4b9b9b4b733903937b6329607d1b60179184019182015283516107f981602884016020880161086f565b01602801949350505050565b602081526000825180602084015261082481604085016020870161086f565b601f01601f19169190910160400192915050565b6000821982111561084b5761084b6108b6565b500190565b600081600019048311821515161561086a5761086a6108b6565b500290565b60005b8381101561088a578181015183820152602001610872565b83811115610899576000848401525b50505050565b6000816108ae576108ae6108b6565b506000190190565b634e487b7160e01b600052601160045260246000fdfe3d2e894c222ba979e2dce2c7d940c0e9bb14306669e9f034eb1bb3979a2069d8a2646970667358221220f3b13b7b58bdbe743297cfa71d680361ad9cd75d6becf3db178aeada4e31c75164736f6c63430008040033",
+  "metadata": "{\"compiler\":{\"version\":\"0.8.4+commit.c7e474f2\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"contract Freeport\",\"name\":\"_freeport\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"anonym\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nftId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"attachment\",\"type\":\"bytes\"}],\"name\":\"AnonymAttachToNFT\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"minter\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nftId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"attachment\",\"type\":\"bytes\"}],\"name\":\"MinterAttachToNFT\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nftId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"attachment\",\"type\":\"bytes\"}],\"name\":\"OwnerAttachToNFT\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"previousAdminRole\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"newAdminRole\",\"type\":\"bytes32\"}],\"name\":\"RoleAdminChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"RoleGranted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"RoleRevoked\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"DEFAULT_ADMIN_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"META_TX_FORWARDER\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"_minterFromNftId\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"minter\",\"type\":\"address\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nftId\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"attachment\",\"type\":\"bytes\"}],\"name\":\"anonymAttachToNFT\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"freeport\",\"outputs\":[{\"internalType\":\"contract Freeport\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"}],\"name\":\"getRoleAdmin\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"grantRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"hasRole\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"forwarder\",\"type\":\"address\"}],\"name\":\"isTrustedForwarder\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nftId\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"attachment\",\"type\":\"bytes\"}],\"name\":\"minterAttachToNFT\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"nftId\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"attachment\",\"type\":\"bytes\"}],\"name\":\"ownerAttachToNFT\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"renounceRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"revokeRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{\"getRoleAdmin(bytes32)\":{\"details\":\"Returns the admin role that controls `role`. See {grantRole} and {revokeRole}. To change a role's admin, use {_setRoleAdmin}.\"},\"grantRole(bytes32,address)\":{\"details\":\"Grants `role` to `account`. If `account` had not been already granted `role`, emits a {RoleGranted} event. Requirements: - the caller must have ``role``'s admin role.\"},\"hasRole(bytes32,address)\":{\"details\":\"Returns `true` if `account` has been granted `role`.\"},\"renounceRole(bytes32,address)\":{\"details\":\"Revokes `role` from the calling account. Roles are often managed via {grantRole} and {revokeRole}: this function's purpose is to provide a mechanism for accounts to lose their privileges if they are compromised (such as when a trusted device is misplaced). If the calling account had been granted `role`, emits a {RoleRevoked} event. Requirements: - the caller must be `account`.\"},\"revokeRole(bytes32,address)\":{\"details\":\"Revokes `role` from `account`. If `account` had been granted `role`, emits a {RoleRevoked} event. Requirements: - the caller must have ``role``'s admin role.\"},\"supportsInterface(bytes4)\":{\"details\":\"See {IERC165-supportsInterface}.\"}},\"version\":1},\"userdoc\":{\"events\":{\"AnonymAttachToNFT(address,uint256,bytes)\":{\"notice\":\"The account `anonym` wished to attach data `attachment` to the NFT type `nftId`. There is absolutely no validation. It is the responsibility of the reader of this event to decide who the sender is and what the attachment means.\"},\"MinterAttachToNFT(address,uint256,bytes)\":{\"notice\":\"The account `minter` wished to attach data `attachment` to the NFT type `nftId`. The `minter` is the minter who created this NFT type, or may create it in the future if it does not exist.\"},\"OwnerAttachToNFT(address,uint256,bytes)\":{\"notice\":\"The account `owner` wished to attach data `attachment` to the NFT type `nftId`. The `owner` owned at least one NFT of this type at the time of the event.\"}},\"kind\":\"user\",\"methods\":{\"_minterFromNftId(uint256)\":{\"notice\":\"Parse an NFT ID into its issuer, its supply, and an arbitrary nonce. This does not imply that the NFTs exist. This is specific to Freeport NFTs. See `freeportParts/Issuance.sol`\"},\"anonymAttachToNFT(uint256,bytes)\":{\"notice\":\"Attach data `attachment` to the NFT type `nftId`, as any account.\"},\"constructor\":{\"notice\":\"Set which NFT contract to refer to. The event `MinterAttachToNFT` is only supported for Freeport-compatible NFTs. The event `OwnerAttachToNFT` is supported for ERC-1155 NFTs, including Freeport.\"},\"freeport()\":{\"notice\":\"This attachment contract refers to the NFT contract in this variable.\"},\"minterAttachToNFT(uint256,bytes)\":{\"notice\":\"Attach data `attachment` to the NFT type `nftId`, as the minter of this NFT type. This only works for NFT IDs in the Freeport format.\"},\"ownerAttachToNFT(uint256,bytes)\":{\"notice\":\"Attach data `attachment` to the NFT type `nftId`, as a current owner of an NFT of this type. This works for NFTs in the ERC-1155 or Freeport standards.\"}},\"notice\":\"The contract NFTAttachment allows users to attach objects to NFTs. Some application can listen for the events and interpret the objects in some way. There are three roles who can attach objects to an NFT: the minter, any current owner, or any anonymous account. A different event is emitted for each role. The attachment data is meant to identify an object hosted externally, such as a CID, a.k.a. Content Identifier, or a DDC URL. The content may be retrieved from Cere DDC or some other store.\",\"version\":1}},\"settings\":{\"compilationTarget\":{\"project:/contracts/NFTAttachment.sol\":\"NFTAttachment\"},\"evmVersion\":\"istanbul\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":10},\"remappings\":[]},\"sources\":{\"@openzeppelin/contracts/token/ERC20/IERC20.sol\":{\"keccak256\":\"0xf8e8d118a7a8b2e134181f7da655f6266aa3a0f9134b2605747139fcb0c5d835\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://9ec48567e7ad06acb670980d5cdf3fd7f3949bf12894f02d68c3bb43e75aa84f\",\"dweb:/ipfs/QmaG3R2J9cz92YT77vFjYrjMNU2wHp4ypwYD62HqDUqS5U\"]},\"project:/contracts/Freeport.sol\":{\"keccak256\":\"0xa89a5606e1bbc4a3e063749b177ce75eb3deb5901d509c741f5cde84ef542415\",\"urls\":[\"bzz-raw://cfb356052d2730f1373efaeb2566a233162e0ee983556cb43b31e850dccc4b4d\",\"dweb:/ipfs/QmbYDB2eCbUnMz8aEQ13RdP13C8CdmcGuApDB57u2JCJin\"]},\"project:/contracts/NFTAttachment.sol\":{\"keccak256\":\"0x175771b8faa3b4e9493ac4d08156b589f67b7ff670528f975fa42e91abfc4f88\",\"urls\":[\"bzz-raw://4d272b44e09dcfeecb7ddd8ae7d56f689bbb8d2b02049cec3370141dcecbebaf\",\"dweb:/ipfs/QmcnXJKGKus5YjDoou8kSizugAgQvrUGTa6GgKCeuQb9uM\"]},\"project:/contracts/access/AccessControl.sol\":{\"keccak256\":\"0x98fac37221212c8f126f198d262a4df86394bd1a9969f61e40739fe8ac013dd8\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://62f98a3c51ff54e1d19c8845da55415c85b4f28c81c0c3b1361eb6eaa905a0c6\",\"dweb:/ipfs/QmTZxiScs2HXZRtscWGjBBXmG4qeFGk1Bq8FGzhbWi1wr3\"]},\"project:/contracts/freeportParts/BaseNFT.sol\":{\"keccak256\":\"0x2b13cfef09bbd2d5d7e681cdbf3f8d7294437dd761282fdc3ade98058ef633c3\",\"urls\":[\"bzz-raw://c713051b9ad441af6020c87db9797780bc746c67cc740018a3aed06dff6c7e7a\",\"dweb:/ipfs/QmeozyvJycaThbBtJy2LnYDZJzX7Eo6UsCMxHacyDgwvvB\"]},\"project:/contracts/freeportParts/Currency.sol\":{\"keccak256\":\"0x697528f47fe2989d1fef56596485917307c9cc1703040d60e56bebacb85b9dc3\",\"urls\":[\"bzz-raw://78226403bc603003a1cf6e3fd1e3da2743f13f9471ff713b304db3f99e2f3ffd\",\"dweb:/ipfs/QmTipFw5JFhmK37FN19EfPvtcsa5XRF3Aj1MqM5csVWfE7\"]},\"project:/contracts/freeportParts/ERC20Adapter.sol\":{\"keccak256\":\"0x66cf6b9c93c0f9f88f62b21c4622a19e1b005a9adf0f4c14ce88013d76d0f19d\",\"urls\":[\"bzz-raw://58fea7ff46ac858835f5d9062924ecfd9d01095d4a4bb44ee136a406a3ed012c\",\"dweb:/ipfs/QmP5JypgCuiDriaJHzcgD6c5764xzfev7ehdGgBwEWgXhp\"]},\"project:/contracts/freeportParts/Issuance.sol\":{\"keccak256\":\"0x1474a148421aba04234c206a7dbc460b1b0bb87e82e687d00d56c5aa22b42eec\",\"urls\":[\"bzz-raw://51750c6ba28a728f87799d767d069a446499866da9e90e256b3b2b35bec664ec\",\"dweb:/ipfs/QmPqZWfVLxfjekEvDzuFYkzRQXeDf6Pjwo3avU7tLbiVYV\"]},\"project:/contracts/freeportParts/JointAccounts.sol\":{\"keccak256\":\"0x46706d42441ad9f47cc1601e1a4bcbb45bc7d15e1e0a6da7299f6a8e309ac9a1\",\"urls\":[\"bzz-raw://cb88d8d36edceca3e6d3ed70131669a804537f6ea91b3ddf787aba89b923d40e\",\"dweb:/ipfs/QmWX7YzXDy3oQHFB55fVoVNxJg9CsoershK2xVUKTgHhPo\"]},\"project:/contracts/freeportParts/MetaTxContext.sol\":{\"keccak256\":\"0x12579308ed77228d87aad495399c8feff27642efa9aae8fe2fd2049da4140459\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://568cafead94d0ecbee30203822e404d1bf53653257f933db70b6a035223189dd\",\"dweb:/ipfs/QmWmgcDLWNeswQF5WGM4zXpdaXcA4sQdWZbGvfSLEZWF2K\"]},\"project:/contracts/freeportParts/SimpleExchange.sol\":{\"keccak256\":\"0x99adff6ce49b17721004385476088979b1d79583ba83c81041c762762f543684\",\"urls\":[\"bzz-raw://fb2ca85b23d41f4b1fc339551bd827e95b19101b95c5fccd6b6590a724265e99\",\"dweb:/ipfs/QmeFYdincJfWLG3412Db8PPb5RBKVW86nuzw3AUxKjMw6B\"]},\"project:/contracts/freeportParts/TransferFees.sol\":{\"keccak256\":\"0xc0bc6eacd5f58ecb10c3e06c9a34d75c7e665d4b85afb9b438d13c9bb515c347\",\"urls\":[\"bzz-raw://d13d012caa46fda6b3853e10a95ce60924f68865b68619591483afea1a3563f2\",\"dweb:/ipfs/QmbeRRXZ8qdEbUrSSzrgfWWr3otMAeB33bXcGGu7JaPAvc\"]},\"project:/contracts/freeportParts/TransferOperator.sol\":{\"keccak256\":\"0xa3b4dd13b4bfd8894da16813415503a755e8fc1a8e081f5a98ffeb7782395d4c\",\"urls\":[\"bzz-raw://539d2f0d0c50ac93ce9f3da7010c06ee2868bb2a27a282a988d88c5644c34609\",\"dweb:/ipfs/Qmf9j9neJ3h9JfekGZ1FA9uYLv599WZkqjMv4KojtCdWZy\"]},\"project:/contracts/token/ERC1155/ERC1155.sol\":{\"keccak256\":\"0xeaafe1c2ab42941716da1c12d401bb708528bd08053d043f16c102d4bb219c8c\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://7b5e012cd4f44be154d1d53e49de4298d47b44393086c71aa7009bc6040eef73\",\"dweb:/ipfs/QmbxfsFYjeksnjW8GYTHEiXx19iN47VdcGdyqaSRPuFvSR\"]},\"project:/contracts/token/ERC1155/IERC1155.sol\":{\"keccak256\":\"0x249bc2a6d919da5f5145950664134cfcf2f66874bda801fd3b8fb861783da079\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://2db9d720fadb1315ba64790815f9f1d80237cca584fc530b8906519bd46ff4cc\",\"dweb:/ipfs/QmXQSGPuGHG5e9ZRVbcUymP3B78cn6ZjfaiaEwd3P3yBCF\"]},\"project:/contracts/token/ERC1155/IERC1155Receiver.sol\":{\"keccak256\":\"0x7c0ea2d284bad1aa002165ba4c5eac30070be8e56b19dba1ac7c8f2c8bd4832c\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://46cd1e78707bb21fc6255c1cc9356537cc767e74f112553ea9305938a325bacb\",\"dweb:/ipfs/QmcG9KekAb77Bh5S62w8SJ4N8qhsmx8ewWF5cWoxC9DEuN\"]},\"project:/contracts/token/ERC1155/extensions/IERC1155MetadataURI.sol\":{\"keccak256\":\"0x6ba0564f6970414d1166ee83127b834bbe7dbf699241a3005eb7ae64a2211975\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://9784827a0575eab840a3b2d42900390724c79139063150955c95f5b730545669\",\"dweb:/ipfs/Qmergdvk1vDFSpXxZSXghPm5SxKBUqrqkZdYmsUSaMwaXK\"]},\"project:/contracts/utils/Address.sol\":{\"keccak256\":\"0x069b2631bb5b5193a58ccf7a06266c7361bd2c20095667af4402817605627f45\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://6a4c96fafff76deda5697c3c5c98cade6e6e1b178254544c106bf360c079ce4e\",\"dweb:/ipfs/QmXmxubE3jnatFgZuN8ay1VV6hZ8WRmhvUjNpeVjki15HX\"]},\"project:/contracts/utils/Context.sol\":{\"keccak256\":\"0xf930d2df426bfcfc1f7415be724f04081c96f4fb9ec8d0e3a521c07692dface0\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://fc2bfdea0d2562c76fb3c4cf70a86c6ba25c5a30e8f8515c95aafdf8383f8395\",\"dweb:/ipfs/QmTbFya18786ckJfLYUoWau9jBTKfmWnWm5XSViWvB7PXN\"]},\"project:/contracts/utils/Strings.sol\":{\"keccak256\":\"0x456e9b3a2bfe189b5249857f624f4139e59331db518483b456c4e587a20552e0\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://1123c9545decc48a011370ebab4bf53dda98524fa21f9498e68851ba8f0ffc0f\",\"dweb:/ipfs/QmUpgMg8EFDnv87ePKUjXxXpJT3qwHRj9VDNSnRxu7T9sy\"]},\"project:/contracts/utils/introspection/ERC165.sol\":{\"keccak256\":\"0x5718c5df9bd67ac68a796961df938821bb5dc0cd4c6118d77e9145afb187409b\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://d10e1d9b26042424789246603906ad06143bf9a928f4e99de8b5e3bdc662f549\",\"dweb:/ipfs/Qmejonoaj5MLekPus229rJQHcC6E9dz2xorjHJR84fMfmn\"]},\"project:/contracts/utils/introspection/IERC165.sol\":{\"keccak256\":\"0xa28007762d9da9db878dd421960c8cb9a10471f47ab5c1b3309bfe48e9e79ff4\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://796ab6e88af7bf0e78def0f059310c903af6a312b565344e0ff524a0f26e81c6\",\"dweb:/ipfs/QmcsVgLgzWdor3UnAztUkXKNGcysm1MPneWksF72AvnwBx\"]}},\"version\":1}",
+  "bytecode": "0x608060405234801561001057600080fd5b50604051610d0f380380610d0f83398101604081905261002f91610067565b6001600160a01b03811661004257600080fd5b600180546001600160a01b0319166001600160a01b0392909216919091179055610095565b600060208284031215610078578081fd5b81516001600160a01b038116811461008e578182fd5b9392505050565b610c6b806100a46000396000f3fe608060405234801561001057600080fd5b50600436106100ba5760003560e01c806301ffc9a7146100bf578063248a9ca3146100e75780632f2ff15d1461010857806336568abe1461011d578063572b6c051461013057806391d14854146101435780639470ad85146101565780639a86e8ce14610181578063a217fddf14610196578063b85f8ca91461019e578063c0ba9f55146101b1578063d2e9277b146101c4578063d547741f146101d8578063f9715b8f146101eb575b600080fd5b6100d26100cd3660046109c9565b6101fe565b60405190151581526020015b60405180910390f35b6100fa6100f5366004610986565b610235565b6040519081526020016100de565b61011b61011636600461099e565b61024a565b005b61011b61012b36600461099e565b610273565b6100d261013e36600461096c565b610306565b6100d261015136600461099e565b61031c565b600154610169906001600160a01b031681565b6040516001600160a01b0390911681526020016100de565b6100fa600080516020610c1683398151915281565b6100fa600081565b61011b6101ac366004610a09565b610345565b61011b6101bf366004610a09565b610416565b6101696101d2366004610986565b60601c90565b61011b6101e636600461099e565b610548565b61011b6101f9366004610a09565b610567565b60006001600160e01b03198216637965db0b60e01b148061022f57506301ffc9a760e01b6001600160e01b03198316145b92915050565b60009081526020819052604090206001015490565b61025382610235565b6102648161025f6105da565b6105fc565b61026e8383610660565b505050565b61027b6105da565b6001600160a01b0316816001600160a01b0316146102f85760405162461bcd60e51b815260206004820152602f60248201527f416363657373436f6e74726f6c3a2063616e206f6e6c792072656e6f756e636560448201526e103937b632b9903337b91039b2b63360891b60648201526084015b60405180910390fd5b61030282826106e5565b5050565b600061022f600080516020610c16833981519152835b6000918252602082815260408084206001600160a01b0393909316845291905290205460ff1690565b826103625760405162461bcd60e51b81526004016102ef90610b50565b600061036c6105da565b9050600061037a8560601c90565b9050806001600160a01b0316826001600160a01b0316146103cb5760405162461bcd60e51b815260206004820152600b60248201526a27b7363c9036b4b73a32b960a91b60448201526064016102ef565b84826001600160a01b03167f5dc5ea79bba163c4e3f9a2bb5350dbe8490685a9191001c5b4422b37f880d3228686604051610407929190610aee565b60405180910390a35050505050565b826104335760405162461bcd60e51b81526004016102ef90610b50565b600061043d6105da565b600154604051627eeac760e11b81526001600160a01b038084166004830152602482018890529293506000929091169062fdd58e9060440160206040518083038186803b15801561048d57600080fd5b505afa1580156104a1573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906104c591906109f1565b90506000811161050c5760405162461bcd60e51b815260206004820152601260248201527127b7363c9031bab93932b73a1037bbb732b960711b60448201526064016102ef565b84826001600160a01b03167f70b7e5963956c4cbfbe79063259fc0996d3333c155342ae9110ca45e85995a558686604051610407929190610aee565b61055182610235565b61055d8161025f6105da565b61026e83836106e5565b826105845760405162461bcd60e51b81526004016102ef90610b50565b600061058e6105da565b905083816001600160a01b03167f4d1230ca9d634685a91b90e38709c77299e0c7591f7ac427d6cd88cf0f6114bf85856040516105cc929190610aee565b60405180910390a350505050565b60006105e533610306565b156105f7575060131936013560601c90565b503390565b610606828261031c565b6103025761061e816001600160a01b03166014610768565b610629836020610768565b60405160200161063a929190610a7f565b60408051601f198184030181529082905262461bcd60e51b82526102ef91600401610b1d565b61066a828261031c565b610302576000828152602081815260408083206001600160a01b03851684529091529020805460ff191660011790556106a16105da565b6001600160a01b0316816001600160a01b0316837f2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d60405160405180910390a45050565b6106ef828261031c565b15610302576000828152602081815260408083206001600160a01b03851684529091529020805460ff191690556107246105da565b6001600160a01b0316816001600160a01b0316837ff6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b60405160405180910390a45050565b60606000610777836002610b99565b610782906002610b81565b6001600160401b038111156107a757634e487b7160e01b600052604160045260246000fd5b6040519080825280601f01601f1916602001820160405280156107d1576020820181803683370190505b509050600360fc1b816000815181106107fa57634e487b7160e01b600052603260045260246000fd5b60200101906001600160f81b031916908160001a905350600f60fb1b8160018151811061083757634e487b7160e01b600052603260045260246000fd5b60200101906001600160f81b031916908160001a905350600061085b846002610b99565b610866906001610b81565b90505b60018111156108fa576f181899199a1a9b1b9c1cb0b131b232b360811b85600f16601081106108a857634e487b7160e01b600052603260045260246000fd5b1a60f81b8282815181106108cc57634e487b7160e01b600052603260045260246000fd5b60200101906001600160f81b031916908160001a90535060049490941c936108f381610be8565b9050610869565b5083156109495760405162461bcd60e51b815260206004820181905260248201527f537472696e67733a20686578206c656e67746820696e73756666696369656e7460448201526064016102ef565b9392505050565b80356001600160a01b038116811461096757600080fd5b919050565b60006020828403121561097d578081fd5b61094982610950565b600060208284031215610997578081fd5b5035919050565b600080604083850312156109b0578081fd5b823591506109c060208401610950565b90509250929050565b6000602082840312156109da578081fd5b81356001600160e01b031981168114610949578182fd5b600060208284031215610a02578081fd5b5051919050565b600080600060408486031215610a1d578081fd5b8335925060208401356001600160401b0380821115610a3a578283fd5b818601915086601f830112610a4d578283fd5b813581811115610a5b578384fd5b876020828501011115610a6c578384fd5b6020830194508093505050509250925092565b76020b1b1b2b9b9a1b7b73a3937b61d1030b1b1b7bab73a1604d1b815260008351610ab1816017850160208801610bb8565b7001034b99036b4b9b9b4b733903937b6329607d1b6017918401918201528351610ae2816028840160208801610bb8565b01602801949350505050565b60208152816020820152818360408301376000818301604090810191909152601f909201601f19160101919050565b6020815260008251806020840152610b3c816040850160208701610bb8565b601f01601f19169190910160400192915050565b6020808252601790820152760c081a5cc81b9bdd0818481d985b1a5908139195081251604a1b604082015260600190565b60008219821115610b9457610b94610bff565b500190565b6000816000190483118215151615610bb357610bb3610bff565b500290565b60005b83811015610bd3578181015183820152602001610bbb565b83811115610be2576000848401525b50505050565b600081610bf757610bf7610bff565b506000190190565b634e487b7160e01b600052601160045260246000fdfe3d2e894c222ba979e2dce2c7d940c0e9bb14306669e9f034eb1bb3979a2069d8a2646970667358221220f7c66f32d0666511241c262ab0cead885c6403db2ecfbdbdceda6cf94b21fbb664736f6c63430008040033",
+  "deployedBytecode": "0x608060405234801561001057600080fd5b50600436106100ba5760003560e01c806301ffc9a7146100bf578063248a9ca3146100e75780632f2ff15d1461010857806336568abe1461011d578063572b6c051461013057806391d14854146101435780639470ad85146101565780639a86e8ce14610181578063a217fddf14610196578063b85f8ca91461019e578063c0ba9f55146101b1578063d2e9277b146101c4578063d547741f146101d8578063f9715b8f146101eb575b600080fd5b6100d26100cd3660046109c9565b6101fe565b60405190151581526020015b60405180910390f35b6100fa6100f5366004610986565b610235565b6040519081526020016100de565b61011b61011636600461099e565b61024a565b005b61011b61012b36600461099e565b610273565b6100d261013e36600461096c565b610306565b6100d261015136600461099e565b61031c565b600154610169906001600160a01b031681565b6040516001600160a01b0390911681526020016100de565b6100fa600080516020610c1683398151915281565b6100fa600081565b61011b6101ac366004610a09565b610345565b61011b6101bf366004610a09565b610416565b6101696101d2366004610986565b60601c90565b61011b6101e636600461099e565b610548565b61011b6101f9366004610a09565b610567565b60006001600160e01b03198216637965db0b60e01b148061022f57506301ffc9a760e01b6001600160e01b03198316145b92915050565b60009081526020819052604090206001015490565b61025382610235565b6102648161025f6105da565b6105fc565b61026e8383610660565b505050565b61027b6105da565b6001600160a01b0316816001600160a01b0316146102f85760405162461bcd60e51b815260206004820152602f60248201527f416363657373436f6e74726f6c3a2063616e206f6e6c792072656e6f756e636560448201526e103937b632b9903337b91039b2b63360891b60648201526084015b60405180910390fd5b61030282826106e5565b5050565b600061022f600080516020610c16833981519152835b6000918252602082815260408084206001600160a01b0393909316845291905290205460ff1690565b826103625760405162461bcd60e51b81526004016102ef90610b50565b600061036c6105da565b9050600061037a8560601c90565b9050806001600160a01b0316826001600160a01b0316146103cb5760405162461bcd60e51b815260206004820152600b60248201526a27b7363c9036b4b73a32b960a91b60448201526064016102ef565b84826001600160a01b03167f5dc5ea79bba163c4e3f9a2bb5350dbe8490685a9191001c5b4422b37f880d3228686604051610407929190610aee565b60405180910390a35050505050565b826104335760405162461bcd60e51b81526004016102ef90610b50565b600061043d6105da565b600154604051627eeac760e11b81526001600160a01b038084166004830152602482018890529293506000929091169062fdd58e9060440160206040518083038186803b15801561048d57600080fd5b505afa1580156104a1573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906104c591906109f1565b90506000811161050c5760405162461bcd60e51b815260206004820152601260248201527127b7363c9031bab93932b73a1037bbb732b960711b60448201526064016102ef565b84826001600160a01b03167f70b7e5963956c4cbfbe79063259fc0996d3333c155342ae9110ca45e85995a558686604051610407929190610aee565b61055182610235565b61055d8161025f6105da565b61026e83836106e5565b826105845760405162461bcd60e51b81526004016102ef90610b50565b600061058e6105da565b905083816001600160a01b03167f4d1230ca9d634685a91b90e38709c77299e0c7591f7ac427d6cd88cf0f6114bf85856040516105cc929190610aee565b60405180910390a350505050565b60006105e533610306565b156105f7575060131936013560601c90565b503390565b610606828261031c565b6103025761061e816001600160a01b03166014610768565b610629836020610768565b60405160200161063a929190610a7f565b60408051601f198184030181529082905262461bcd60e51b82526102ef91600401610b1d565b61066a828261031c565b610302576000828152602081815260408083206001600160a01b03851684529091529020805460ff191660011790556106a16105da565b6001600160a01b0316816001600160a01b0316837f2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d60405160405180910390a45050565b6106ef828261031c565b15610302576000828152602081815260408083206001600160a01b03851684529091529020805460ff191690556107246105da565b6001600160a01b0316816001600160a01b0316837ff6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b60405160405180910390a45050565b60606000610777836002610b99565b610782906002610b81565b6001600160401b038111156107a757634e487b7160e01b600052604160045260246000fd5b6040519080825280601f01601f1916602001820160405280156107d1576020820181803683370190505b509050600360fc1b816000815181106107fa57634e487b7160e01b600052603260045260246000fd5b60200101906001600160f81b031916908160001a905350600f60fb1b8160018151811061083757634e487b7160e01b600052603260045260246000fd5b60200101906001600160f81b031916908160001a905350600061085b846002610b99565b610866906001610b81565b90505b60018111156108fa576f181899199a1a9b1b9c1cb0b131b232b360811b85600f16601081106108a857634e487b7160e01b600052603260045260246000fd5b1a60f81b8282815181106108cc57634e487b7160e01b600052603260045260246000fd5b60200101906001600160f81b031916908160001a90535060049490941c936108f381610be8565b9050610869565b5083156109495760405162461bcd60e51b815260206004820181905260248201527f537472696e67733a20686578206c656e67746820696e73756666696369656e7460448201526064016102ef565b9392505050565b80356001600160a01b038116811461096757600080fd5b919050565b60006020828403121561097d578081fd5b61094982610950565b600060208284031215610997578081fd5b5035919050565b600080604083850312156109b0578081fd5b823591506109c060208401610950565b90509250929050565b6000602082840312156109da578081fd5b81356001600160e01b031981168114610949578182fd5b600060208284031215610a02578081fd5b5051919050565b600080600060408486031215610a1d578081fd5b8335925060208401356001600160401b0380821115610a3a578283fd5b818601915086601f830112610a4d578283fd5b813581811115610a5b578384fd5b876020828501011115610a6c578384fd5b6020830194508093505050509250925092565b76020b1b1b2b9b9a1b7b73a3937b61d1030b1b1b7bab73a1604d1b815260008351610ab1816017850160208801610bb8565b7001034b99036b4b9b9b4b733903937b6329607d1b6017918401918201528351610ae2816028840160208801610bb8565b01602801949350505050565b60208152816020820152818360408301376000818301604090810191909152601f909201601f19160101919050565b6020815260008251806020840152610b3c816040850160208701610bb8565b601f01601f19169190910160400192915050565b6020808252601790820152760c081a5cc81b9bdd0818481d985b1a5908139195081251604a1b604082015260600190565b60008219821115610b9457610b94610bff565b500190565b6000816000190483118215151615610bb357610bb3610bff565b500290565b60005b83811015610bd3578181015183820152602001610bbb565b83811115610be2576000848401525b50505050565b600081610bf757610bf7610bff565b506000190190565b634e487b7160e01b600052601160045260246000fdfe3d2e894c222ba979e2dce2c7d940c0e9bb14306669e9f034eb1bb3979a2069d8a2646970667358221220f7c66f32d0666511241c262ab0cead885c6403db2ecfbdbdceda6cf94b21fbb664736f6c63430008040033",
   "immutableReferences": {},
   "generatedSources": [
     {
       "ast": {
         "nodeType": "YulBlock",
-        "src": "0:326:34",
+        "src": "0:342:34",
         "statements": [
           {
             "nodeType": "YulBlock",
@@ -330,12 +436,12 @@
           {
             "body": {
               "nodeType": "YulBlock",
-              "src": "95:229:34",
+              "src": "111:229:34",
               "statements": [
                 {
                   "body": {
                     "nodeType": "YulBlock",
-                    "src": "141:26:34",
+                    "src": "157:26:34",
                     "statements": [
                       {
                         "expression": {
@@ -343,24 +449,24 @@
                             {
                               "name": "value0",
                               "nodeType": "YulIdentifier",
-                              "src": "150:6:34"
+                              "src": "166:6:34"
                             },
                             {
                               "name": "value0",
                               "nodeType": "YulIdentifier",
-                              "src": "158:6:34"
+                              "src": "174:6:34"
                             }
                           ],
                           "functionName": {
                             "name": "revert",
                             "nodeType": "YulIdentifier",
-                            "src": "143:6:34"
+                            "src": "159:6:34"
                           },
                           "nodeType": "YulFunctionCall",
-                          "src": "143:22:34"
+                          "src": "159:22:34"
                         },
                         "nodeType": "YulExpressionStatement",
-                        "src": "143:22:34"
+                        "src": "159:22:34"
                       }
                     ]
                   },
@@ -371,26 +477,26 @@
                           {
                             "name": "dataEnd",
                             "nodeType": "YulIdentifier",
-                            "src": "116:7:34"
+                            "src": "132:7:34"
                           },
                           {
                             "name": "headStart",
                             "nodeType": "YulIdentifier",
-                            "src": "125:9:34"
+                            "src": "141:9:34"
                           }
                         ],
                         "functionName": {
                           "name": "sub",
                           "nodeType": "YulIdentifier",
-                          "src": "112:3:34"
+                          "src": "128:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "112:23:34"
+                        "src": "128:23:34"
                       },
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
-                        "src": "137:2:34",
+                        "src": "153:2:34",
                         "type": "",
                         "value": "32"
                       }
@@ -398,38 +504,38 @@
                     "functionName": {
                       "name": "slt",
                       "nodeType": "YulIdentifier",
-                      "src": "108:3:34"
+                      "src": "124:3:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "108:32:34"
+                    "src": "124:32:34"
                   },
                   "nodeType": "YulIf",
-                  "src": "105:2:34"
+                  "src": "121:2:34"
                 },
                 {
                   "nodeType": "YulVariableDeclaration",
-                  "src": "176:29:34",
+                  "src": "192:29:34",
                   "value": {
                     "arguments": [
                       {
                         "name": "headStart",
                         "nodeType": "YulIdentifier",
-                        "src": "195:9:34"
+                        "src": "211:9:34"
                       }
                     ],
                     "functionName": {
                       "name": "mload",
                       "nodeType": "YulIdentifier",
-                      "src": "189:5:34"
+                      "src": "205:5:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "189:16:34"
+                    "src": "205:16:34"
                   },
                   "variables": [
                     {
                       "name": "value",
                       "nodeType": "YulTypedName",
-                      "src": "180:5:34",
+                      "src": "196:5:34",
                       "type": ""
                     }
                   ]
@@ -437,7 +543,7 @@
                 {
                   "body": {
                     "nodeType": "YulBlock",
-                    "src": "268:26:34",
+                    "src": "284:26:34",
                     "statements": [
                       {
                         "expression": {
@@ -445,24 +551,24 @@
                             {
                               "name": "value0",
                               "nodeType": "YulIdentifier",
-                              "src": "277:6:34"
+                              "src": "293:6:34"
                             },
                             {
                               "name": "value0",
                               "nodeType": "YulIdentifier",
-                              "src": "285:6:34"
+                              "src": "301:6:34"
                             }
                           ],
                           "functionName": {
                             "name": "revert",
                             "nodeType": "YulIdentifier",
-                            "src": "270:6:34"
+                            "src": "286:6:34"
                           },
                           "nodeType": "YulFunctionCall",
-                          "src": "270:22:34"
+                          "src": "286:22:34"
                         },
                         "nodeType": "YulExpressionStatement",
-                        "src": "270:22:34"
+                        "src": "286:22:34"
                       }
                     ]
                   },
@@ -473,14 +579,14 @@
                           {
                             "name": "value",
                             "nodeType": "YulIdentifier",
-                            "src": "227:5:34"
+                            "src": "243:5:34"
                           },
                           {
                             "arguments": [
                               {
                                 "name": "value",
                                 "nodeType": "YulIdentifier",
-                                "src": "238:5:34"
+                                "src": "254:5:34"
                               },
                               {
                                 "arguments": [
@@ -489,14 +595,14 @@
                                       {
                                         "kind": "number",
                                         "nodeType": "YulLiteral",
-                                        "src": "253:3:34",
+                                        "src": "269:3:34",
                                         "type": "",
                                         "value": "160"
                                       },
                                       {
                                         "kind": "number",
                                         "nodeType": "YulLiteral",
-                                        "src": "258:1:34",
+                                        "src": "274:1:34",
                                         "type": "",
                                         "value": "1"
                                       }
@@ -504,15 +610,15 @@
                                     "functionName": {
                                       "name": "shl",
                                       "nodeType": "YulIdentifier",
-                                      "src": "249:3:34"
+                                      "src": "265:3:34"
                                     },
                                     "nodeType": "YulFunctionCall",
-                                    "src": "249:11:34"
+                                    "src": "265:11:34"
                                   },
                                   {
                                     "kind": "number",
                                     "nodeType": "YulLiteral",
-                                    "src": "262:1:34",
+                                    "src": "278:1:34",
                                     "type": "",
                                     "value": "1"
                                   }
@@ -520,72 +626,72 @@
                                 "functionName": {
                                   "name": "sub",
                                   "nodeType": "YulIdentifier",
-                                  "src": "245:3:34"
+                                  "src": "261:3:34"
                                 },
                                 "nodeType": "YulFunctionCall",
-                                "src": "245:19:34"
+                                "src": "261:19:34"
                               }
                             ],
                             "functionName": {
                               "name": "and",
                               "nodeType": "YulIdentifier",
-                              "src": "234:3:34"
+                              "src": "250:3:34"
                             },
                             "nodeType": "YulFunctionCall",
-                            "src": "234:31:34"
+                            "src": "250:31:34"
                           }
                         ],
                         "functionName": {
                           "name": "eq",
                           "nodeType": "YulIdentifier",
-                          "src": "224:2:34"
+                          "src": "240:2:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "224:42:34"
+                        "src": "240:42:34"
                       }
                     ],
                     "functionName": {
                       "name": "iszero",
                       "nodeType": "YulIdentifier",
-                      "src": "217:6:34"
+                      "src": "233:6:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "217:50:34"
+                    "src": "233:50:34"
                   },
                   "nodeType": "YulIf",
-                  "src": "214:2:34"
+                  "src": "230:2:34"
                 },
                 {
                   "nodeType": "YulAssignment",
-                  "src": "303:15:34",
+                  "src": "319:15:34",
                   "value": {
                     "name": "value",
                     "nodeType": "YulIdentifier",
-                    "src": "313:5:34"
+                    "src": "329:5:34"
                   },
                   "variableNames": [
                     {
                       "name": "value0",
                       "nodeType": "YulIdentifier",
-                      "src": "303:6:34"
+                      "src": "319:6:34"
                     }
                   ]
                 }
               ]
             },
-            "name": "abi_decode_tuple_t_address_fromMemory",
+            "name": "abi_decode_tuple_t_contract$_Freeport_$947_fromMemory",
             "nodeType": "YulFunctionDefinition",
             "parameters": [
               {
                 "name": "headStart",
                 "nodeType": "YulTypedName",
-                "src": "61:9:34",
+                "src": "77:9:34",
                 "type": ""
               },
               {
                 "name": "dataEnd",
                 "nodeType": "YulTypedName",
-                "src": "72:7:34",
+                "src": "88:7:34",
                 "type": ""
               }
             ],
@@ -593,15 +699,15 @@
               {
                 "name": "value0",
                 "nodeType": "YulTypedName",
-                "src": "84:6:34",
+                "src": "100:6:34",
                 "type": ""
               }
             ],
-            "src": "14:310:34"
+            "src": "14:326:34"
           }
         ]
       },
-      "contents": "{\n    { }\n    function abi_decode_tuple_t_address_fromMemory(headStart, dataEnd) -> value0\n    {\n        if slt(sub(dataEnd, headStart), 32) { revert(value0, value0) }\n        let value := mload(headStart)\n        if iszero(eq(value, and(value, sub(shl(160, 1), 1)))) { revert(value0, value0) }\n        value0 := value\n    }\n}",
+      "contents": "{\n    { }\n    function abi_decode_tuple_t_contract$_Freeport_$947_fromMemory(headStart, dataEnd) -> value0\n    {\n        if slt(sub(dataEnd, headStart), 32) { revert(value0, value0) }\n        let value := mload(headStart)\n        if iszero(eq(value, and(value, sub(shl(160, 1), 1)))) { revert(value0, value0) }\n        value0 := value\n    }\n}",
       "id": 34,
       "language": "Yul",
       "name": "#utility.yul"
@@ -611,7 +717,7 @@
     {
       "ast": {
         "nodeType": "YulBlock",
-        "src": "0:4808:34",
+        "src": "0:7591:34",
         "statements": [
           {
             "nodeType": "YulBlock",
@@ -1507,12 +1613,12 @@
           {
             "body": {
               "nodeType": "YulBlock",
-              "src": "1255:171:34",
+              "src": "1238:120:34",
               "statements": [
                 {
                   "body": {
                     "nodeType": "YulBlock",
-                    "src": "1301:26:34",
+                    "src": "1284:26:34",
                     "statements": [
                       {
                         "expression": {
@@ -1520,24 +1626,24 @@
                             {
                               "name": "value0",
                               "nodeType": "YulIdentifier",
-                              "src": "1310:6:34"
+                              "src": "1293:6:34"
                             },
                             {
                               "name": "value0",
                               "nodeType": "YulIdentifier",
-                              "src": "1318:6:34"
+                              "src": "1301:6:34"
                             }
                           ],
                           "functionName": {
                             "name": "revert",
                             "nodeType": "YulIdentifier",
-                            "src": "1303:6:34"
+                            "src": "1286:6:34"
                           },
                           "nodeType": "YulFunctionCall",
-                          "src": "1303:22:34"
+                          "src": "1286:22:34"
                         },
                         "nodeType": "YulExpressionStatement",
-                        "src": "1303:22:34"
+                        "src": "1286:22:34"
                       }
                     ]
                   },
@@ -1548,128 +1654,83 @@
                           {
                             "name": "dataEnd",
                             "nodeType": "YulIdentifier",
-                            "src": "1276:7:34"
+                            "src": "1259:7:34"
                           },
                           {
                             "name": "headStart",
                             "nodeType": "YulIdentifier",
-                            "src": "1285:9:34"
+                            "src": "1268:9:34"
                           }
                         ],
                         "functionName": {
                           "name": "sub",
                           "nodeType": "YulIdentifier",
-                          "src": "1272:3:34"
+                          "src": "1255:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "1272:23:34"
+                        "src": "1255:23:34"
                       },
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
-                        "src": "1297:2:34",
+                        "src": "1280:2:34",
                         "type": "",
-                        "value": "64"
+                        "value": "32"
                       }
                     ],
                     "functionName": {
                       "name": "slt",
                       "nodeType": "YulIdentifier",
-                      "src": "1268:3:34"
+                      "src": "1251:3:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "1268:32:34"
+                    "src": "1251:32:34"
                   },
                   "nodeType": "YulIf",
-                  "src": "1265:2:34"
+                  "src": "1248:2:34"
                 },
                 {
                   "nodeType": "YulAssignment",
-                  "src": "1336:33:34",
+                  "src": "1319:33:34",
                   "value": {
                     "arguments": [
                       {
                         "name": "headStart",
                         "nodeType": "YulIdentifier",
-                        "src": "1359:9:34"
+                        "src": "1342:9:34"
                       }
                     ],
                     "functionName": {
                       "name": "calldataload",
                       "nodeType": "YulIdentifier",
-                      "src": "1346:12:34"
+                      "src": "1329:12:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "1346:23:34"
+                    "src": "1329:23:34"
                   },
                   "variableNames": [
                     {
                       "name": "value0",
                       "nodeType": "YulIdentifier",
-                      "src": "1336:6:34"
-                    }
-                  ]
-                },
-                {
-                  "nodeType": "YulAssignment",
-                  "src": "1378:42:34",
-                  "value": {
-                    "arguments": [
-                      {
-                        "arguments": [
-                          {
-                            "name": "headStart",
-                            "nodeType": "YulIdentifier",
-                            "src": "1405:9:34"
-                          },
-                          {
-                            "kind": "number",
-                            "nodeType": "YulLiteral",
-                            "src": "1416:2:34",
-                            "type": "",
-                            "value": "32"
-                          }
-                        ],
-                        "functionName": {
-                          "name": "add",
-                          "nodeType": "YulIdentifier",
-                          "src": "1401:3:34"
-                        },
-                        "nodeType": "YulFunctionCall",
-                        "src": "1401:18:34"
-                      }
-                    ],
-                    "functionName": {
-                      "name": "calldataload",
-                      "nodeType": "YulIdentifier",
-                      "src": "1388:12:34"
-                    },
-                    "nodeType": "YulFunctionCall",
-                    "src": "1388:32:34"
-                  },
-                  "variableNames": [
-                    {
-                      "name": "value1",
-                      "nodeType": "YulIdentifier",
-                      "src": "1378:6:34"
+                      "src": "1319:6:34"
                     }
                   ]
                 }
               ]
             },
-            "name": "abi_decode_tuple_t_uint256t_bytes32",
+            "name": "abi_decode_tuple_t_uint256",
             "nodeType": "YulFunctionDefinition",
             "parameters": [
               {
                 "name": "headStart",
                 "nodeType": "YulTypedName",
-                "src": "1213:9:34",
+                "src": "1204:9:34",
                 "type": ""
               },
               {
                 "name": "dataEnd",
                 "nodeType": "YulTypedName",
-                "src": "1224:7:34",
+                "src": "1215:7:34",
                 "type": ""
               }
             ],
@@ -1677,22 +1738,795 @@
               {
                 "name": "value0",
                 "nodeType": "YulTypedName",
-                "src": "1236:6:34",
+                "src": "1227:6:34",
+                "type": ""
+              }
+            ],
+            "src": "1168:190:34"
+          },
+          {
+            "body": {
+              "nodeType": "YulBlock",
+              "src": "1444:113:34",
+              "statements": [
+                {
+                  "body": {
+                    "nodeType": "YulBlock",
+                    "src": "1490:26:34",
+                    "statements": [
+                      {
+                        "expression": {
+                          "arguments": [
+                            {
+                              "name": "value0",
+                              "nodeType": "YulIdentifier",
+                              "src": "1499:6:34"
+                            },
+                            {
+                              "name": "value0",
+                              "nodeType": "YulIdentifier",
+                              "src": "1507:6:34"
+                            }
+                          ],
+                          "functionName": {
+                            "name": "revert",
+                            "nodeType": "YulIdentifier",
+                            "src": "1492:6:34"
+                          },
+                          "nodeType": "YulFunctionCall",
+                          "src": "1492:22:34"
+                        },
+                        "nodeType": "YulExpressionStatement",
+                        "src": "1492:22:34"
+                      }
+                    ]
+                  },
+                  "condition": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "name": "dataEnd",
+                            "nodeType": "YulIdentifier",
+                            "src": "1465:7:34"
+                          },
+                          {
+                            "name": "headStart",
+                            "nodeType": "YulIdentifier",
+                            "src": "1474:9:34"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "sub",
+                          "nodeType": "YulIdentifier",
+                          "src": "1461:3:34"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "1461:23:34"
+                      },
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "1486:2:34",
+                        "type": "",
+                        "value": "32"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "slt",
+                      "nodeType": "YulIdentifier",
+                      "src": "1457:3:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "1457:32:34"
+                  },
+                  "nodeType": "YulIf",
+                  "src": "1454:2:34"
+                },
+                {
+                  "nodeType": "YulAssignment",
+                  "src": "1525:26:34",
+                  "value": {
+                    "arguments": [
+                      {
+                        "name": "headStart",
+                        "nodeType": "YulIdentifier",
+                        "src": "1541:9:34"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "mload",
+                      "nodeType": "YulIdentifier",
+                      "src": "1535:5:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "1535:16:34"
+                  },
+                  "variableNames": [
+                    {
+                      "name": "value0",
+                      "nodeType": "YulIdentifier",
+                      "src": "1525:6:34"
+                    }
+                  ]
+                }
+              ]
+            },
+            "name": "abi_decode_tuple_t_uint256_fromMemory",
+            "nodeType": "YulFunctionDefinition",
+            "parameters": [
+              {
+                "name": "headStart",
+                "nodeType": "YulTypedName",
+                "src": "1410:9:34",
+                "type": ""
+              },
+              {
+                "name": "dataEnd",
+                "nodeType": "YulTypedName",
+                "src": "1421:7:34",
+                "type": ""
+              }
+            ],
+            "returnVariables": [
+              {
+                "name": "value0",
+                "nodeType": "YulTypedName",
+                "src": "1433:6:34",
+                "type": ""
+              }
+            ],
+            "src": "1363:194:34"
+          },
+          {
+            "body": {
+              "nodeType": "YulBlock",
+              "src": "1668:603:34",
+              "statements": [
+                {
+                  "body": {
+                    "nodeType": "YulBlock",
+                    "src": "1714:26:34",
+                    "statements": [
+                      {
+                        "expression": {
+                          "arguments": [
+                            {
+                              "name": "value2",
+                              "nodeType": "YulIdentifier",
+                              "src": "1723:6:34"
+                            },
+                            {
+                              "name": "value2",
+                              "nodeType": "YulIdentifier",
+                              "src": "1731:6:34"
+                            }
+                          ],
+                          "functionName": {
+                            "name": "revert",
+                            "nodeType": "YulIdentifier",
+                            "src": "1716:6:34"
+                          },
+                          "nodeType": "YulFunctionCall",
+                          "src": "1716:22:34"
+                        },
+                        "nodeType": "YulExpressionStatement",
+                        "src": "1716:22:34"
+                      }
+                    ]
+                  },
+                  "condition": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "name": "dataEnd",
+                            "nodeType": "YulIdentifier",
+                            "src": "1689:7:34"
+                          },
+                          {
+                            "name": "headStart",
+                            "nodeType": "YulIdentifier",
+                            "src": "1698:9:34"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "sub",
+                          "nodeType": "YulIdentifier",
+                          "src": "1685:3:34"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "1685:23:34"
+                      },
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "1710:2:34",
+                        "type": "",
+                        "value": "64"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "slt",
+                      "nodeType": "YulIdentifier",
+                      "src": "1681:3:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "1681:32:34"
+                  },
+                  "nodeType": "YulIf",
+                  "src": "1678:2:34"
+                },
+                {
+                  "nodeType": "YulAssignment",
+                  "src": "1749:33:34",
+                  "value": {
+                    "arguments": [
+                      {
+                        "name": "headStart",
+                        "nodeType": "YulIdentifier",
+                        "src": "1772:9:34"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "calldataload",
+                      "nodeType": "YulIdentifier",
+                      "src": "1759:12:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "1759:23:34"
+                  },
+                  "variableNames": [
+                    {
+                      "name": "value0",
+                      "nodeType": "YulIdentifier",
+                      "src": "1749:6:34"
+                    }
+                  ]
+                },
+                {
+                  "nodeType": "YulVariableDeclaration",
+                  "src": "1791:46:34",
+                  "value": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "name": "headStart",
+                            "nodeType": "YulIdentifier",
+                            "src": "1822:9:34"
+                          },
+                          {
+                            "kind": "number",
+                            "nodeType": "YulLiteral",
+                            "src": "1833:2:34",
+                            "type": "",
+                            "value": "32"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "add",
+                          "nodeType": "YulIdentifier",
+                          "src": "1818:3:34"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "1818:18:34"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "calldataload",
+                      "nodeType": "YulIdentifier",
+                      "src": "1805:12:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "1805:32:34"
+                  },
+                  "variables": [
+                    {
+                      "name": "offset",
+                      "nodeType": "YulTypedName",
+                      "src": "1795:6:34",
+                      "type": ""
+                    }
+                  ]
+                },
+                {
+                  "nodeType": "YulVariableDeclaration",
+                  "src": "1846:28:34",
+                  "value": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "kind": "number",
+                            "nodeType": "YulLiteral",
+                            "src": "1864:2:34",
+                            "type": "",
+                            "value": "64"
+                          },
+                          {
+                            "kind": "number",
+                            "nodeType": "YulLiteral",
+                            "src": "1868:1:34",
+                            "type": "",
+                            "value": "1"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "shl",
+                          "nodeType": "YulIdentifier",
+                          "src": "1860:3:34"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "1860:10:34"
+                      },
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "1872:1:34",
+                        "type": "",
+                        "value": "1"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "sub",
+                      "nodeType": "YulIdentifier",
+                      "src": "1856:3:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "1856:18:34"
+                  },
+                  "variables": [
+                    {
+                      "name": "_1",
+                      "nodeType": "YulTypedName",
+                      "src": "1850:2:34",
+                      "type": ""
+                    }
+                  ]
+                },
+                {
+                  "body": {
+                    "nodeType": "YulBlock",
+                    "src": "1901:26:34",
+                    "statements": [
+                      {
+                        "expression": {
+                          "arguments": [
+                            {
+                              "name": "value2",
+                              "nodeType": "YulIdentifier",
+                              "src": "1910:6:34"
+                            },
+                            {
+                              "name": "value2",
+                              "nodeType": "YulIdentifier",
+                              "src": "1918:6:34"
+                            }
+                          ],
+                          "functionName": {
+                            "name": "revert",
+                            "nodeType": "YulIdentifier",
+                            "src": "1903:6:34"
+                          },
+                          "nodeType": "YulFunctionCall",
+                          "src": "1903:22:34"
+                        },
+                        "nodeType": "YulExpressionStatement",
+                        "src": "1903:22:34"
+                      }
+                    ]
+                  },
+                  "condition": {
+                    "arguments": [
+                      {
+                        "name": "offset",
+                        "nodeType": "YulIdentifier",
+                        "src": "1889:6:34"
+                      },
+                      {
+                        "name": "_1",
+                        "nodeType": "YulIdentifier",
+                        "src": "1897:2:34"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "gt",
+                      "nodeType": "YulIdentifier",
+                      "src": "1886:2:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "1886:14:34"
+                  },
+                  "nodeType": "YulIf",
+                  "src": "1883:2:34"
+                },
+                {
+                  "nodeType": "YulVariableDeclaration",
+                  "src": "1936:32:34",
+                  "value": {
+                    "arguments": [
+                      {
+                        "name": "headStart",
+                        "nodeType": "YulIdentifier",
+                        "src": "1950:9:34"
+                      },
+                      {
+                        "name": "offset",
+                        "nodeType": "YulIdentifier",
+                        "src": "1961:6:34"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "add",
+                      "nodeType": "YulIdentifier",
+                      "src": "1946:3:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "1946:22:34"
+                  },
+                  "variables": [
+                    {
+                      "name": "_2",
+                      "nodeType": "YulTypedName",
+                      "src": "1940:2:34",
+                      "type": ""
+                    }
+                  ]
+                },
+                {
+                  "body": {
+                    "nodeType": "YulBlock",
+                    "src": "2016:26:34",
+                    "statements": [
+                      {
+                        "expression": {
+                          "arguments": [
+                            {
+                              "name": "value2",
+                              "nodeType": "YulIdentifier",
+                              "src": "2025:6:34"
+                            },
+                            {
+                              "name": "value2",
+                              "nodeType": "YulIdentifier",
+                              "src": "2033:6:34"
+                            }
+                          ],
+                          "functionName": {
+                            "name": "revert",
+                            "nodeType": "YulIdentifier",
+                            "src": "2018:6:34"
+                          },
+                          "nodeType": "YulFunctionCall",
+                          "src": "2018:22:34"
+                        },
+                        "nodeType": "YulExpressionStatement",
+                        "src": "2018:22:34"
+                      }
+                    ]
+                  },
+                  "condition": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "arguments": [
+                              {
+                                "name": "_2",
+                                "nodeType": "YulIdentifier",
+                                "src": "1995:2:34"
+                              },
+                              {
+                                "kind": "number",
+                                "nodeType": "YulLiteral",
+                                "src": "1999:4:34",
+                                "type": "",
+                                "value": "0x1f"
+                              }
+                            ],
+                            "functionName": {
+                              "name": "add",
+                              "nodeType": "YulIdentifier",
+                              "src": "1991:3:34"
+                            },
+                            "nodeType": "YulFunctionCall",
+                            "src": "1991:13:34"
+                          },
+                          {
+                            "name": "dataEnd",
+                            "nodeType": "YulIdentifier",
+                            "src": "2006:7:34"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "slt",
+                          "nodeType": "YulIdentifier",
+                          "src": "1987:3:34"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "1987:27:34"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "iszero",
+                      "nodeType": "YulIdentifier",
+                      "src": "1980:6:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "1980:35:34"
+                  },
+                  "nodeType": "YulIf",
+                  "src": "1977:2:34"
+                },
+                {
+                  "nodeType": "YulVariableDeclaration",
+                  "src": "2051:30:34",
+                  "value": {
+                    "arguments": [
+                      {
+                        "name": "_2",
+                        "nodeType": "YulIdentifier",
+                        "src": "2078:2:34"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "calldataload",
+                      "nodeType": "YulIdentifier",
+                      "src": "2065:12:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "2065:16:34"
+                  },
+                  "variables": [
+                    {
+                      "name": "length",
+                      "nodeType": "YulTypedName",
+                      "src": "2055:6:34",
+                      "type": ""
+                    }
+                  ]
+                },
+                {
+                  "body": {
+                    "nodeType": "YulBlock",
+                    "src": "2108:26:34",
+                    "statements": [
+                      {
+                        "expression": {
+                          "arguments": [
+                            {
+                              "name": "value2",
+                              "nodeType": "YulIdentifier",
+                              "src": "2117:6:34"
+                            },
+                            {
+                              "name": "value2",
+                              "nodeType": "YulIdentifier",
+                              "src": "2125:6:34"
+                            }
+                          ],
+                          "functionName": {
+                            "name": "revert",
+                            "nodeType": "YulIdentifier",
+                            "src": "2110:6:34"
+                          },
+                          "nodeType": "YulFunctionCall",
+                          "src": "2110:22:34"
+                        },
+                        "nodeType": "YulExpressionStatement",
+                        "src": "2110:22:34"
+                      }
+                    ]
+                  },
+                  "condition": {
+                    "arguments": [
+                      {
+                        "name": "length",
+                        "nodeType": "YulIdentifier",
+                        "src": "2096:6:34"
+                      },
+                      {
+                        "name": "_1",
+                        "nodeType": "YulIdentifier",
+                        "src": "2104:2:34"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "gt",
+                      "nodeType": "YulIdentifier",
+                      "src": "2093:2:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "2093:14:34"
+                  },
+                  "nodeType": "YulIf",
+                  "src": "2090:2:34"
+                },
+                {
+                  "body": {
+                    "nodeType": "YulBlock",
+                    "src": "2184:26:34",
+                    "statements": [
+                      {
+                        "expression": {
+                          "arguments": [
+                            {
+                              "name": "value2",
+                              "nodeType": "YulIdentifier",
+                              "src": "2193:6:34"
+                            },
+                            {
+                              "name": "value2",
+                              "nodeType": "YulIdentifier",
+                              "src": "2201:6:34"
+                            }
+                          ],
+                          "functionName": {
+                            "name": "revert",
+                            "nodeType": "YulIdentifier",
+                            "src": "2186:6:34"
+                          },
+                          "nodeType": "YulFunctionCall",
+                          "src": "2186:22:34"
+                        },
+                        "nodeType": "YulExpressionStatement",
+                        "src": "2186:22:34"
+                      }
+                    ]
+                  },
+                  "condition": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "arguments": [
+                              {
+                                "name": "_2",
+                                "nodeType": "YulIdentifier",
+                                "src": "2157:2:34"
+                              },
+                              {
+                                "name": "length",
+                                "nodeType": "YulIdentifier",
+                                "src": "2161:6:34"
+                              }
+                            ],
+                            "functionName": {
+                              "name": "add",
+                              "nodeType": "YulIdentifier",
+                              "src": "2153:3:34"
+                            },
+                            "nodeType": "YulFunctionCall",
+                            "src": "2153:15:34"
+                          },
+                          {
+                            "kind": "number",
+                            "nodeType": "YulLiteral",
+                            "src": "2170:2:34",
+                            "type": "",
+                            "value": "32"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "add",
+                          "nodeType": "YulIdentifier",
+                          "src": "2149:3:34"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "2149:24:34"
+                      },
+                      {
+                        "name": "dataEnd",
+                        "nodeType": "YulIdentifier",
+                        "src": "2175:7:34"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "gt",
+                      "nodeType": "YulIdentifier",
+                      "src": "2146:2:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "2146:37:34"
+                  },
+                  "nodeType": "YulIf",
+                  "src": "2143:2:34"
+                },
+                {
+                  "nodeType": "YulAssignment",
+                  "src": "2219:21:34",
+                  "value": {
+                    "arguments": [
+                      {
+                        "name": "_2",
+                        "nodeType": "YulIdentifier",
+                        "src": "2233:2:34"
+                      },
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "2237:2:34",
+                        "type": "",
+                        "value": "32"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "add",
+                      "nodeType": "YulIdentifier",
+                      "src": "2229:3:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "2229:11:34"
+                  },
+                  "variableNames": [
+                    {
+                      "name": "value1",
+                      "nodeType": "YulIdentifier",
+                      "src": "2219:6:34"
+                    }
+                  ]
+                },
+                {
+                  "nodeType": "YulAssignment",
+                  "src": "2249:16:34",
+                  "value": {
+                    "name": "length",
+                    "nodeType": "YulIdentifier",
+                    "src": "2259:6:34"
+                  },
+                  "variableNames": [
+                    {
+                      "name": "value2",
+                      "nodeType": "YulIdentifier",
+                      "src": "2249:6:34"
+                    }
+                  ]
+                }
+              ]
+            },
+            "name": "abi_decode_tuple_t_uint256t_bytes_calldata_ptr",
+            "nodeType": "YulFunctionDefinition",
+            "parameters": [
+              {
+                "name": "headStart",
+                "nodeType": "YulTypedName",
+                "src": "1618:9:34",
+                "type": ""
+              },
+              {
+                "name": "dataEnd",
+                "nodeType": "YulTypedName",
+                "src": "1629:7:34",
+                "type": ""
+              }
+            ],
+            "returnVariables": [
+              {
+                "name": "value0",
+                "nodeType": "YulTypedName",
+                "src": "1641:6:34",
                 "type": ""
               },
               {
                 "name": "value1",
                 "nodeType": "YulTypedName",
-                "src": "1244:6:34",
+                "src": "1649:6:34",
+                "type": ""
+              },
+              {
+                "name": "value2",
+                "nodeType": "YulTypedName",
+                "src": "1657:6:34",
                 "type": ""
               }
             ],
-            "src": "1168:258:34"
+            "src": "1562:709:34"
           },
           {
             "body": {
               "nodeType": "YulBlock",
-              "src": "1820:397:34",
+              "src": "2665:397:34",
               "statements": [
                 {
                   "expression": {
@@ -1700,12 +2534,12 @@
                       {
                         "name": "pos",
                         "nodeType": "YulIdentifier",
-                        "src": "1837:3:34"
+                        "src": "2682:3:34"
                       },
                       {
                         "kind": "string",
                         "nodeType": "YulLiteral",
-                        "src": "1842:25:34",
+                        "src": "2687:25:34",
                         "type": "",
                         "value": "AccessControl: account "
                       }
@@ -1713,38 +2547,38 @@
                     "functionName": {
                       "name": "mstore",
                       "nodeType": "YulIdentifier",
-                      "src": "1830:6:34"
+                      "src": "2675:6:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "1830:38:34"
+                    "src": "2675:38:34"
                   },
                   "nodeType": "YulExpressionStatement",
-                  "src": "1830:38:34"
+                  "src": "2675:38:34"
                 },
                 {
                   "nodeType": "YulVariableDeclaration",
-                  "src": "1877:27:34",
+                  "src": "2722:27:34",
                   "value": {
                     "arguments": [
                       {
                         "name": "value0",
                         "nodeType": "YulIdentifier",
-                        "src": "1897:6:34"
+                        "src": "2742:6:34"
                       }
                     ],
                     "functionName": {
                       "name": "mload",
                       "nodeType": "YulIdentifier",
-                      "src": "1891:5:34"
+                      "src": "2736:5:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "1891:13:34"
+                    "src": "2736:13:34"
                   },
                   "variables": [
                     {
                       "name": "length",
                       "nodeType": "YulTypedName",
-                      "src": "1881:6:34",
+                      "src": "2726:6:34",
                       "type": ""
                     }
                   ]
@@ -1757,12 +2591,12 @@
                           {
                             "name": "value0",
                             "nodeType": "YulIdentifier",
-                            "src": "1939:6:34"
+                            "src": "2784:6:34"
                           },
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
-                            "src": "1947:4:34",
+                            "src": "2792:4:34",
                             "type": "",
                             "value": "0x20"
                           }
@@ -1770,22 +2604,22 @@
                         "functionName": {
                           "name": "add",
                           "nodeType": "YulIdentifier",
-                          "src": "1935:3:34"
+                          "src": "2780:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "1935:17:34"
+                        "src": "2780:17:34"
                       },
                       {
                         "arguments": [
                           {
                             "name": "pos",
                             "nodeType": "YulIdentifier",
-                            "src": "1958:3:34"
+                            "src": "2803:3:34"
                           },
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
-                            "src": "1963:2:34",
+                            "src": "2808:2:34",
                             "type": "",
                             "value": "23"
                           }
@@ -1793,57 +2627,57 @@
                         "functionName": {
                           "name": "add",
                           "nodeType": "YulIdentifier",
-                          "src": "1954:3:34"
+                          "src": "2799:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "1954:12:34"
+                        "src": "2799:12:34"
                       },
                       {
                         "name": "length",
                         "nodeType": "YulIdentifier",
-                        "src": "1968:6:34"
+                        "src": "2813:6:34"
                       }
                     ],
                     "functionName": {
                       "name": "copy_memory_to_memory",
                       "nodeType": "YulIdentifier",
-                      "src": "1913:21:34"
+                      "src": "2758:21:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "1913:62:34"
+                    "src": "2758:62:34"
                   },
                   "nodeType": "YulExpressionStatement",
-                  "src": "1913:62:34"
+                  "src": "2758:62:34"
                 },
                 {
                   "nodeType": "YulVariableDeclaration",
-                  "src": "1984:26:34",
+                  "src": "2829:26:34",
                   "value": {
                     "arguments": [
                       {
                         "name": "pos",
                         "nodeType": "YulIdentifier",
-                        "src": "1998:3:34"
+                        "src": "2843:3:34"
                       },
                       {
                         "name": "length",
                         "nodeType": "YulIdentifier",
-                        "src": "2003:6:34"
+                        "src": "2848:6:34"
                       }
                     ],
                     "functionName": {
                       "name": "add",
                       "nodeType": "YulIdentifier",
-                      "src": "1994:3:34"
+                      "src": "2839:3:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "1994:16:34"
+                    "src": "2839:16:34"
                   },
                   "variables": [
                     {
                       "name": "_1",
                       "nodeType": "YulTypedName",
-                      "src": "1988:2:34",
+                      "src": "2833:2:34",
                       "type": ""
                     }
                   ]
@@ -1856,12 +2690,12 @@
                           {
                             "name": "_1",
                             "nodeType": "YulIdentifier",
-                            "src": "2030:2:34"
+                            "src": "2875:2:34"
                           },
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
-                            "src": "2034:2:34",
+                            "src": "2879:2:34",
                             "type": "",
                             "value": "23"
                           }
@@ -1869,15 +2703,15 @@
                         "functionName": {
                           "name": "add",
                           "nodeType": "YulIdentifier",
-                          "src": "2026:3:34"
+                          "src": "2871:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "2026:11:34"
+                        "src": "2871:11:34"
                       },
                       {
                         "kind": "string",
                         "nodeType": "YulLiteral",
-                        "src": "2039:19:34",
+                        "src": "2884:19:34",
                         "type": "",
                         "value": " is missing role "
                       }
@@ -1885,38 +2719,38 @@
                     "functionName": {
                       "name": "mstore",
                       "nodeType": "YulIdentifier",
-                      "src": "2019:6:34"
+                      "src": "2864:6:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "2019:40:34"
+                    "src": "2864:40:34"
                   },
                   "nodeType": "YulExpressionStatement",
-                  "src": "2019:40:34"
+                  "src": "2864:40:34"
                 },
                 {
                   "nodeType": "YulVariableDeclaration",
-                  "src": "2068:29:34",
+                  "src": "2913:29:34",
                   "value": {
                     "arguments": [
                       {
                         "name": "value1",
                         "nodeType": "YulIdentifier",
-                        "src": "2090:6:34"
+                        "src": "2935:6:34"
                       }
                     ],
                     "functionName": {
                       "name": "mload",
                       "nodeType": "YulIdentifier",
-                      "src": "2084:5:34"
+                      "src": "2929:5:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "2084:13:34"
+                    "src": "2929:13:34"
                   },
                   "variables": [
                     {
                       "name": "length_1",
                       "nodeType": "YulTypedName",
-                      "src": "2072:8:34",
+                      "src": "2917:8:34",
                       "type": ""
                     }
                   ]
@@ -1929,12 +2763,12 @@
                           {
                             "name": "value1",
                             "nodeType": "YulIdentifier",
-                            "src": "2132:6:34"
+                            "src": "2977:6:34"
                           },
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
-                            "src": "2140:4:34",
+                            "src": "2985:4:34",
                             "type": "",
                             "value": "0x20"
                           }
@@ -1942,22 +2776,22 @@
                         "functionName": {
                           "name": "add",
                           "nodeType": "YulIdentifier",
-                          "src": "2128:3:34"
+                          "src": "2973:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "2128:17:34"
+                        "src": "2973:17:34"
                       },
                       {
                         "arguments": [
                           {
                             "name": "_1",
                             "nodeType": "YulIdentifier",
-                            "src": "2151:2:34"
+                            "src": "2996:2:34"
                           },
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
-                            "src": "2155:2:34",
+                            "src": "3000:2:34",
                             "type": "",
                             "value": "40"
                           }
@@ -1965,31 +2799,31 @@
                         "functionName": {
                           "name": "add",
                           "nodeType": "YulIdentifier",
-                          "src": "2147:3:34"
+                          "src": "2992:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "2147:11:34"
+                        "src": "2992:11:34"
                       },
                       {
                         "name": "length_1",
                         "nodeType": "YulIdentifier",
-                        "src": "2160:8:34"
+                        "src": "3005:8:34"
                       }
                     ],
                     "functionName": {
                       "name": "copy_memory_to_memory",
                       "nodeType": "YulIdentifier",
-                      "src": "2106:21:34"
+                      "src": "2951:21:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "2106:63:34"
+                    "src": "2951:63:34"
                   },
                   "nodeType": "YulExpressionStatement",
-                  "src": "2106:63:34"
+                  "src": "2951:63:34"
                 },
                 {
                   "nodeType": "YulAssignment",
-                  "src": "2178:33:34",
+                  "src": "3023:33:34",
                   "value": {
                     "arguments": [
                       {
@@ -1997,26 +2831,26 @@
                           {
                             "name": "_1",
                             "nodeType": "YulIdentifier",
-                            "src": "2193:2:34"
+                            "src": "3038:2:34"
                           },
                           {
                             "name": "length_1",
                             "nodeType": "YulIdentifier",
-                            "src": "2197:8:34"
+                            "src": "3042:8:34"
                           }
                         ],
                         "functionName": {
                           "name": "add",
                           "nodeType": "YulIdentifier",
-                          "src": "2189:3:34"
+                          "src": "3034:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "2189:17:34"
+                        "src": "3034:17:34"
                       },
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
-                        "src": "2208:2:34",
+                        "src": "3053:2:34",
                         "type": "",
                         "value": "40"
                       }
@@ -2024,16 +2858,16 @@
                     "functionName": {
                       "name": "add",
                       "nodeType": "YulIdentifier",
-                      "src": "2185:3:34"
+                      "src": "3030:3:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "2185:26:34"
+                    "src": "3030:26:34"
                   },
                   "variableNames": [
                     {
                       "name": "end",
                       "nodeType": "YulIdentifier",
-                      "src": "2178:3:34"
+                      "src": "3023:3:34"
                     }
                   ]
                 }
@@ -2045,19 +2879,19 @@
               {
                 "name": "pos",
                 "nodeType": "YulTypedName",
-                "src": "1788:3:34",
+                "src": "2633:3:34",
                 "type": ""
               },
               {
                 "name": "value1",
                 "nodeType": "YulTypedName",
-                "src": "1793:6:34",
+                "src": "2638:6:34",
                 "type": ""
               },
               {
                 "name": "value0",
                 "nodeType": "YulTypedName",
-                "src": "1801:6:34",
+                "src": "2646:6:34",
                 "type": ""
               }
             ],
@@ -2065,31 +2899,31 @@
               {
                 "name": "end",
                 "nodeType": "YulTypedName",
-                "src": "1812:3:34",
+                "src": "2657:3:34",
                 "type": ""
               }
             ],
-            "src": "1431:786:34"
+            "src": "2276:786:34"
           },
           {
             "body": {
               "nodeType": "YulBlock",
-              "src": "2323:102:34",
+              "src": "3168:102:34",
               "statements": [
                 {
                   "nodeType": "YulAssignment",
-                  "src": "2333:26:34",
+                  "src": "3178:26:34",
                   "value": {
                     "arguments": [
                       {
                         "name": "headStart",
                         "nodeType": "YulIdentifier",
-                        "src": "2345:9:34"
+                        "src": "3190:9:34"
                       },
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
-                        "src": "2356:2:34",
+                        "src": "3201:2:34",
                         "type": "",
                         "value": "32"
                       }
@@ -2097,16 +2931,16 @@
                     "functionName": {
                       "name": "add",
                       "nodeType": "YulIdentifier",
-                      "src": "2341:3:34"
+                      "src": "3186:3:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "2341:18:34"
+                    "src": "3186:18:34"
                   },
                   "variableNames": [
                     {
                       "name": "tail",
                       "nodeType": "YulIdentifier",
-                      "src": "2333:4:34"
+                      "src": "3178:4:34"
                     }
                   ]
                 },
@@ -2116,14 +2950,14 @@
                       {
                         "name": "headStart",
                         "nodeType": "YulIdentifier",
-                        "src": "2375:9:34"
+                        "src": "3220:9:34"
                       },
                       {
                         "arguments": [
                           {
                             "name": "value0",
                             "nodeType": "YulIdentifier",
-                            "src": "2390:6:34"
+                            "src": "3235:6:34"
                           },
                           {
                             "arguments": [
@@ -2132,14 +2966,14 @@
                                   {
                                     "kind": "number",
                                     "nodeType": "YulLiteral",
-                                    "src": "2406:3:34",
+                                    "src": "3251:3:34",
                                     "type": "",
                                     "value": "160"
                                   },
                                   {
                                     "kind": "number",
                                     "nodeType": "YulLiteral",
-                                    "src": "2411:1:34",
+                                    "src": "3256:1:34",
                                     "type": "",
                                     "value": "1"
                                   }
@@ -2147,15 +2981,15 @@
                                 "functionName": {
                                   "name": "shl",
                                   "nodeType": "YulIdentifier",
-                                  "src": "2402:3:34"
+                                  "src": "3247:3:34"
                                 },
                                 "nodeType": "YulFunctionCall",
-                                "src": "2402:11:34"
+                                "src": "3247:11:34"
                               },
                               {
                                 "kind": "number",
                                 "nodeType": "YulLiteral",
-                                "src": "2415:1:34",
+                                "src": "3260:1:34",
                                 "type": "",
                                 "value": "1"
                               }
@@ -2163,31 +2997,31 @@
                             "functionName": {
                               "name": "sub",
                               "nodeType": "YulIdentifier",
-                              "src": "2398:3:34"
+                              "src": "3243:3:34"
                             },
                             "nodeType": "YulFunctionCall",
-                            "src": "2398:19:34"
+                            "src": "3243:19:34"
                           }
                         ],
                         "functionName": {
                           "name": "and",
                           "nodeType": "YulIdentifier",
-                          "src": "2386:3:34"
+                          "src": "3231:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "2386:32:34"
+                        "src": "3231:32:34"
                       }
                     ],
                     "functionName": {
                       "name": "mstore",
                       "nodeType": "YulIdentifier",
-                      "src": "2368:6:34"
+                      "src": "3213:6:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "2368:51:34"
+                    "src": "3213:51:34"
                   },
                   "nodeType": "YulExpressionStatement",
-                  "src": "2368:51:34"
+                  "src": "3213:51:34"
                 }
               ]
             },
@@ -2197,13 +3031,13 @@
               {
                 "name": "headStart",
                 "nodeType": "YulTypedName",
-                "src": "2292:9:34",
+                "src": "3137:9:34",
                 "type": ""
               },
               {
                 "name": "value0",
                 "nodeType": "YulTypedName",
-                "src": "2303:6:34",
+                "src": "3148:6:34",
                 "type": ""
               }
             ],
@@ -2211,48 +3045,48 @@
               {
                 "name": "tail",
                 "nodeType": "YulTypedName",
-                "src": "2314:4:34",
+                "src": "3159:4:34",
                 "type": ""
               }
             ],
-            "src": "2222:203:34"
+            "src": "3067:203:34"
           },
           {
             "body": {
               "nodeType": "YulBlock",
-              "src": "2525:92:34",
+              "src": "3404:145:34",
               "statements": [
                 {
                   "nodeType": "YulAssignment",
-                  "src": "2535:26:34",
+                  "src": "3414:26:34",
                   "value": {
                     "arguments": [
                       {
                         "name": "headStart",
                         "nodeType": "YulIdentifier",
-                        "src": "2547:9:34"
+                        "src": "3426:9:34"
                       },
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
-                        "src": "2558:2:34",
+                        "src": "3437:2:34",
                         "type": "",
-                        "value": "32"
+                        "value": "64"
                       }
                     ],
                     "functionName": {
                       "name": "add",
                       "nodeType": "YulIdentifier",
-                      "src": "2543:3:34"
+                      "src": "3422:3:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "2543:18:34"
+                    "src": "3422:18:34"
                   },
                   "variableNames": [
                     {
                       "name": "tail",
                       "nodeType": "YulIdentifier",
-                      "src": "2535:4:34"
+                      "src": "3414:4:34"
                     }
                   ]
                 },
@@ -2262,7 +3096,202 @@
                       {
                         "name": "headStart",
                         "nodeType": "YulIdentifier",
-                        "src": "2577:9:34"
+                        "src": "3456:9:34"
+                      },
+                      {
+                        "arguments": [
+                          {
+                            "name": "value0",
+                            "nodeType": "YulIdentifier",
+                            "src": "3471:6:34"
+                          },
+                          {
+                            "arguments": [
+                              {
+                                "arguments": [
+                                  {
+                                    "kind": "number",
+                                    "nodeType": "YulLiteral",
+                                    "src": "3487:3:34",
+                                    "type": "",
+                                    "value": "160"
+                                  },
+                                  {
+                                    "kind": "number",
+                                    "nodeType": "YulLiteral",
+                                    "src": "3492:1:34",
+                                    "type": "",
+                                    "value": "1"
+                                  }
+                                ],
+                                "functionName": {
+                                  "name": "shl",
+                                  "nodeType": "YulIdentifier",
+                                  "src": "3483:3:34"
+                                },
+                                "nodeType": "YulFunctionCall",
+                                "src": "3483:11:34"
+                              },
+                              {
+                                "kind": "number",
+                                "nodeType": "YulLiteral",
+                                "src": "3496:1:34",
+                                "type": "",
+                                "value": "1"
+                              }
+                            ],
+                            "functionName": {
+                              "name": "sub",
+                              "nodeType": "YulIdentifier",
+                              "src": "3479:3:34"
+                            },
+                            "nodeType": "YulFunctionCall",
+                            "src": "3479:19:34"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "and",
+                          "nodeType": "YulIdentifier",
+                          "src": "3467:3:34"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "3467:32:34"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "mstore",
+                      "nodeType": "YulIdentifier",
+                      "src": "3449:6:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "3449:51:34"
+                  },
+                  "nodeType": "YulExpressionStatement",
+                  "src": "3449:51:34"
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "name": "headStart",
+                            "nodeType": "YulIdentifier",
+                            "src": "3520:9:34"
+                          },
+                          {
+                            "kind": "number",
+                            "nodeType": "YulLiteral",
+                            "src": "3531:2:34",
+                            "type": "",
+                            "value": "32"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "add",
+                          "nodeType": "YulIdentifier",
+                          "src": "3516:3:34"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "3516:18:34"
+                      },
+                      {
+                        "name": "value1",
+                        "nodeType": "YulIdentifier",
+                        "src": "3536:6:34"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "mstore",
+                      "nodeType": "YulIdentifier",
+                      "src": "3509:6:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "3509:34:34"
+                  },
+                  "nodeType": "YulExpressionStatement",
+                  "src": "3509:34:34"
+                }
+              ]
+            },
+            "name": "abi_encode_tuple_t_address_t_uint256__to_t_address_t_uint256__fromStack_reversed",
+            "nodeType": "YulFunctionDefinition",
+            "parameters": [
+              {
+                "name": "headStart",
+                "nodeType": "YulTypedName",
+                "src": "3365:9:34",
+                "type": ""
+              },
+              {
+                "name": "value1",
+                "nodeType": "YulTypedName",
+                "src": "3376:6:34",
+                "type": ""
+              },
+              {
+                "name": "value0",
+                "nodeType": "YulTypedName",
+                "src": "3384:6:34",
+                "type": ""
+              }
+            ],
+            "returnVariables": [
+              {
+                "name": "tail",
+                "nodeType": "YulTypedName",
+                "src": "3395:4:34",
+                "type": ""
+              }
+            ],
+            "src": "3275:274:34"
+          },
+          {
+            "body": {
+              "nodeType": "YulBlock",
+              "src": "3649:92:34",
+              "statements": [
+                {
+                  "nodeType": "YulAssignment",
+                  "src": "3659:26:34",
+                  "value": {
+                    "arguments": [
+                      {
+                        "name": "headStart",
+                        "nodeType": "YulIdentifier",
+                        "src": "3671:9:34"
+                      },
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "3682:2:34",
+                        "type": "",
+                        "value": "32"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "add",
+                      "nodeType": "YulIdentifier",
+                      "src": "3667:3:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "3667:18:34"
+                  },
+                  "variableNames": [
+                    {
+                      "name": "tail",
+                      "nodeType": "YulIdentifier",
+                      "src": "3659:4:34"
+                    }
+                  ]
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "name": "headStart",
+                        "nodeType": "YulIdentifier",
+                        "src": "3701:9:34"
                       },
                       {
                         "arguments": [
@@ -2271,37 +3300,37 @@
                               {
                                 "name": "value0",
                                 "nodeType": "YulIdentifier",
-                                "src": "2602:6:34"
+                                "src": "3726:6:34"
                               }
                             ],
                             "functionName": {
                               "name": "iszero",
                               "nodeType": "YulIdentifier",
-                              "src": "2595:6:34"
+                              "src": "3719:6:34"
                             },
                             "nodeType": "YulFunctionCall",
-                            "src": "2595:14:34"
+                            "src": "3719:14:34"
                           }
                         ],
                         "functionName": {
                           "name": "iszero",
                           "nodeType": "YulIdentifier",
-                          "src": "2588:6:34"
+                          "src": "3712:6:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "2588:22:34"
+                        "src": "3712:22:34"
                       }
                     ],
                     "functionName": {
                       "name": "mstore",
                       "nodeType": "YulIdentifier",
-                      "src": "2570:6:34"
+                      "src": "3694:6:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "2570:41:34"
+                    "src": "3694:41:34"
                   },
                   "nodeType": "YulExpressionStatement",
-                  "src": "2570:41:34"
+                  "src": "3694:41:34"
                 }
               ]
             },
@@ -2311,13 +3340,13 @@
               {
                 "name": "headStart",
                 "nodeType": "YulTypedName",
-                "src": "2494:9:34",
+                "src": "3618:9:34",
                 "type": ""
               },
               {
                 "name": "value0",
                 "nodeType": "YulTypedName",
-                "src": "2505:6:34",
+                "src": "3629:6:34",
                 "type": ""
               }
             ],
@@ -2325,31 +3354,31 @@
               {
                 "name": "tail",
                 "nodeType": "YulTypedName",
-                "src": "2516:4:34",
+                "src": "3640:4:34",
                 "type": ""
               }
             ],
-            "src": "2430:187:34"
+            "src": "3554:187:34"
           },
           {
             "body": {
               "nodeType": "YulBlock",
-              "src": "2723:76:34",
+              "src": "3847:76:34",
               "statements": [
                 {
                   "nodeType": "YulAssignment",
-                  "src": "2733:26:34",
+                  "src": "3857:26:34",
                   "value": {
                     "arguments": [
                       {
                         "name": "headStart",
                         "nodeType": "YulIdentifier",
-                        "src": "2745:9:34"
+                        "src": "3869:9:34"
                       },
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
-                        "src": "2756:2:34",
+                        "src": "3880:2:34",
                         "type": "",
                         "value": "32"
                       }
@@ -2357,16 +3386,16 @@
                     "functionName": {
                       "name": "add",
                       "nodeType": "YulIdentifier",
-                      "src": "2741:3:34"
+                      "src": "3865:3:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "2741:18:34"
+                    "src": "3865:18:34"
                   },
                   "variableNames": [
                     {
                       "name": "tail",
                       "nodeType": "YulIdentifier",
-                      "src": "2733:4:34"
+                      "src": "3857:4:34"
                     }
                   ]
                 },
@@ -2376,24 +3405,24 @@
                       {
                         "name": "headStart",
                         "nodeType": "YulIdentifier",
-                        "src": "2775:9:34"
+                        "src": "3899:9:34"
                       },
                       {
                         "name": "value0",
                         "nodeType": "YulIdentifier",
-                        "src": "2786:6:34"
+                        "src": "3910:6:34"
                       }
                     ],
                     "functionName": {
                       "name": "mstore",
                       "nodeType": "YulIdentifier",
-                      "src": "2768:6:34"
+                      "src": "3892:6:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "2768:25:34"
+                    "src": "3892:25:34"
                   },
                   "nodeType": "YulExpressionStatement",
-                  "src": "2768:25:34"
+                  "src": "3892:25:34"
                 }
               ]
             },
@@ -2403,13 +3432,13 @@
               {
                 "name": "headStart",
                 "nodeType": "YulTypedName",
-                "src": "2692:9:34",
+                "src": "3816:9:34",
                 "type": ""
               },
               {
                 "name": "value0",
                 "nodeType": "YulTypedName",
-                "src": "2703:6:34",
+                "src": "3827:6:34",
                 "type": ""
               }
             ],
@@ -2417,16 +3446,16 @@
               {
                 "name": "tail",
                 "nodeType": "YulTypedName",
-                "src": "2714:4:34",
+                "src": "3838:4:34",
                 "type": ""
               }
             ],
-            "src": "2622:177:34"
+            "src": "3746:177:34"
           },
           {
             "body": {
               "nodeType": "YulBlock",
-              "src": "2925:262:34",
+              "src": "4057:262:34",
               "statements": [
                 {
                   "expression": {
@@ -2434,12 +3463,12 @@
                       {
                         "name": "headStart",
                         "nodeType": "YulIdentifier",
-                        "src": "2942:9:34"
+                        "src": "4074:9:34"
                       },
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
-                        "src": "2953:2:34",
+                        "src": "4085:2:34",
                         "type": "",
                         "value": "32"
                       }
@@ -2447,38 +3476,497 @@
                     "functionName": {
                       "name": "mstore",
                       "nodeType": "YulIdentifier",
-                      "src": "2935:6:34"
+                      "src": "4067:6:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "2935:21:34"
+                    "src": "4067:21:34"
                   },
                   "nodeType": "YulExpressionStatement",
-                  "src": "2935:21:34"
+                  "src": "4067:21:34"
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "name": "headStart",
+                            "nodeType": "YulIdentifier",
+                            "src": "4108:9:34"
+                          },
+                          {
+                            "kind": "number",
+                            "nodeType": "YulLiteral",
+                            "src": "4119:2:34",
+                            "type": "",
+                            "value": "32"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "add",
+                          "nodeType": "YulIdentifier",
+                          "src": "4104:3:34"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "4104:18:34"
+                      },
+                      {
+                        "name": "value1",
+                        "nodeType": "YulIdentifier",
+                        "src": "4124:6:34"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "mstore",
+                      "nodeType": "YulIdentifier",
+                      "src": "4097:6:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "4097:34:34"
+                  },
+                  "nodeType": "YulExpressionStatement",
+                  "src": "4097:34:34"
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "name": "headStart",
+                            "nodeType": "YulIdentifier",
+                            "src": "4157:9:34"
+                          },
+                          {
+                            "kind": "number",
+                            "nodeType": "YulLiteral",
+                            "src": "4168:2:34",
+                            "type": "",
+                            "value": "64"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "add",
+                          "nodeType": "YulIdentifier",
+                          "src": "4153:3:34"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "4153:18:34"
+                      },
+                      {
+                        "name": "value0",
+                        "nodeType": "YulIdentifier",
+                        "src": "4173:6:34"
+                      },
+                      {
+                        "name": "value1",
+                        "nodeType": "YulIdentifier",
+                        "src": "4181:6:34"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "calldatacopy",
+                      "nodeType": "YulIdentifier",
+                      "src": "4140:12:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "4140:48:34"
+                  },
+                  "nodeType": "YulExpressionStatement",
+                  "src": "4140:48:34"
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "arguments": [
+                              {
+                                "name": "headStart",
+                                "nodeType": "YulIdentifier",
+                                "src": "4212:9:34"
+                              },
+                              {
+                                "name": "value1",
+                                "nodeType": "YulIdentifier",
+                                "src": "4223:6:34"
+                              }
+                            ],
+                            "functionName": {
+                              "name": "add",
+                              "nodeType": "YulIdentifier",
+                              "src": "4208:3:34"
+                            },
+                            "nodeType": "YulFunctionCall",
+                            "src": "4208:22:34"
+                          },
+                          {
+                            "kind": "number",
+                            "nodeType": "YulLiteral",
+                            "src": "4232:2:34",
+                            "type": "",
+                            "value": "64"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "add",
+                          "nodeType": "YulIdentifier",
+                          "src": "4204:3:34"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "4204:31:34"
+                      },
+                      {
+                        "name": "tail",
+                        "nodeType": "YulIdentifier",
+                        "src": "4237:4:34"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "mstore",
+                      "nodeType": "YulIdentifier",
+                      "src": "4197:6:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "4197:45:34"
+                  },
+                  "nodeType": "YulExpressionStatement",
+                  "src": "4197:45:34"
+                },
+                {
+                  "nodeType": "YulAssignment",
+                  "src": "4251:62:34",
+                  "value": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "name": "headStart",
+                            "nodeType": "YulIdentifier",
+                            "src": "4267:9:34"
+                          },
+                          {
+                            "arguments": [
+                              {
+                                "arguments": [
+                                  {
+                                    "name": "value1",
+                                    "nodeType": "YulIdentifier",
+                                    "src": "4286:6:34"
+                                  },
+                                  {
+                                    "kind": "number",
+                                    "nodeType": "YulLiteral",
+                                    "src": "4294:2:34",
+                                    "type": "",
+                                    "value": "31"
+                                  }
+                                ],
+                                "functionName": {
+                                  "name": "add",
+                                  "nodeType": "YulIdentifier",
+                                  "src": "4282:3:34"
+                                },
+                                "nodeType": "YulFunctionCall",
+                                "src": "4282:15:34"
+                              },
+                              {
+                                "arguments": [
+                                  {
+                                    "kind": "number",
+                                    "nodeType": "YulLiteral",
+                                    "src": "4303:2:34",
+                                    "type": "",
+                                    "value": "31"
+                                  }
+                                ],
+                                "functionName": {
+                                  "name": "not",
+                                  "nodeType": "YulIdentifier",
+                                  "src": "4299:3:34"
+                                },
+                                "nodeType": "YulFunctionCall",
+                                "src": "4299:7:34"
+                              }
+                            ],
+                            "functionName": {
+                              "name": "and",
+                              "nodeType": "YulIdentifier",
+                              "src": "4278:3:34"
+                            },
+                            "nodeType": "YulFunctionCall",
+                            "src": "4278:29:34"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "add",
+                          "nodeType": "YulIdentifier",
+                          "src": "4263:3:34"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "4263:45:34"
+                      },
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "4310:2:34",
+                        "type": "",
+                        "value": "64"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "add",
+                      "nodeType": "YulIdentifier",
+                      "src": "4259:3:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "4259:54:34"
+                  },
+                  "variableNames": [
+                    {
+                      "name": "tail",
+                      "nodeType": "YulIdentifier",
+                      "src": "4251:4:34"
+                    }
+                  ]
+                }
+              ]
+            },
+            "name": "abi_encode_tuple_t_bytes_calldata_ptr__to_t_bytes_memory_ptr__fromStack_reversed",
+            "nodeType": "YulFunctionDefinition",
+            "parameters": [
+              {
+                "name": "headStart",
+                "nodeType": "YulTypedName",
+                "src": "4018:9:34",
+                "type": ""
+              },
+              {
+                "name": "value1",
+                "nodeType": "YulTypedName",
+                "src": "4029:6:34",
+                "type": ""
+              },
+              {
+                "name": "value0",
+                "nodeType": "YulTypedName",
+                "src": "4037:6:34",
+                "type": ""
+              }
+            ],
+            "returnVariables": [
+              {
+                "name": "tail",
+                "nodeType": "YulTypedName",
+                "src": "4048:4:34",
+                "type": ""
+              }
+            ],
+            "src": "3928:391:34"
+          },
+          {
+            "body": {
+              "nodeType": "YulBlock",
+              "src": "4441:102:34",
+              "statements": [
+                {
+                  "nodeType": "YulAssignment",
+                  "src": "4451:26:34",
+                  "value": {
+                    "arguments": [
+                      {
+                        "name": "headStart",
+                        "nodeType": "YulIdentifier",
+                        "src": "4463:9:34"
+                      },
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "4474:2:34",
+                        "type": "",
+                        "value": "32"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "add",
+                      "nodeType": "YulIdentifier",
+                      "src": "4459:3:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "4459:18:34"
+                  },
+                  "variableNames": [
+                    {
+                      "name": "tail",
+                      "nodeType": "YulIdentifier",
+                      "src": "4451:4:34"
+                    }
+                  ]
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "name": "headStart",
+                        "nodeType": "YulIdentifier",
+                        "src": "4493:9:34"
+                      },
+                      {
+                        "arguments": [
+                          {
+                            "name": "value0",
+                            "nodeType": "YulIdentifier",
+                            "src": "4508:6:34"
+                          },
+                          {
+                            "arguments": [
+                              {
+                                "arguments": [
+                                  {
+                                    "kind": "number",
+                                    "nodeType": "YulLiteral",
+                                    "src": "4524:3:34",
+                                    "type": "",
+                                    "value": "160"
+                                  },
+                                  {
+                                    "kind": "number",
+                                    "nodeType": "YulLiteral",
+                                    "src": "4529:1:34",
+                                    "type": "",
+                                    "value": "1"
+                                  }
+                                ],
+                                "functionName": {
+                                  "name": "shl",
+                                  "nodeType": "YulIdentifier",
+                                  "src": "4520:3:34"
+                                },
+                                "nodeType": "YulFunctionCall",
+                                "src": "4520:11:34"
+                              },
+                              {
+                                "kind": "number",
+                                "nodeType": "YulLiteral",
+                                "src": "4533:1:34",
+                                "type": "",
+                                "value": "1"
+                              }
+                            ],
+                            "functionName": {
+                              "name": "sub",
+                              "nodeType": "YulIdentifier",
+                              "src": "4516:3:34"
+                            },
+                            "nodeType": "YulFunctionCall",
+                            "src": "4516:19:34"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "and",
+                          "nodeType": "YulIdentifier",
+                          "src": "4504:3:34"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "4504:32:34"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "mstore",
+                      "nodeType": "YulIdentifier",
+                      "src": "4486:6:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "4486:51:34"
+                  },
+                  "nodeType": "YulExpressionStatement",
+                  "src": "4486:51:34"
+                }
+              ]
+            },
+            "name": "abi_encode_tuple_t_contract$_Freeport_$947__to_t_address__fromStack_reversed",
+            "nodeType": "YulFunctionDefinition",
+            "parameters": [
+              {
+                "name": "headStart",
+                "nodeType": "YulTypedName",
+                "src": "4410:9:34",
+                "type": ""
+              },
+              {
+                "name": "value0",
+                "nodeType": "YulTypedName",
+                "src": "4421:6:34",
+                "type": ""
+              }
+            ],
+            "returnVariables": [
+              {
+                "name": "tail",
+                "nodeType": "YulTypedName",
+                "src": "4432:4:34",
+                "type": ""
+              }
+            ],
+            "src": "4324:219:34"
+          },
+          {
+            "body": {
+              "nodeType": "YulBlock",
+              "src": "4669:262:34",
+              "statements": [
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "name": "headStart",
+                        "nodeType": "YulIdentifier",
+                        "src": "4686:9:34"
+                      },
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "4697:2:34",
+                        "type": "",
+                        "value": "32"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "mstore",
+                      "nodeType": "YulIdentifier",
+                      "src": "4679:6:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "4679:21:34"
+                  },
+                  "nodeType": "YulExpressionStatement",
+                  "src": "4679:21:34"
                 },
                 {
                   "nodeType": "YulVariableDeclaration",
-                  "src": "2965:27:34",
+                  "src": "4709:27:34",
                   "value": {
                     "arguments": [
                       {
                         "name": "value0",
                         "nodeType": "YulIdentifier",
-                        "src": "2985:6:34"
+                        "src": "4729:6:34"
                       }
                     ],
                     "functionName": {
                       "name": "mload",
                       "nodeType": "YulIdentifier",
-                      "src": "2979:5:34"
+                      "src": "4723:5:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "2979:13:34"
+                    "src": "4723:13:34"
                   },
                   "variables": [
                     {
                       "name": "length",
                       "nodeType": "YulTypedName",
-                      "src": "2969:6:34",
+                      "src": "4713:6:34",
                       "type": ""
                     }
                   ]
@@ -2491,12 +3979,12 @@
                           {
                             "name": "headStart",
                             "nodeType": "YulIdentifier",
-                            "src": "3012:9:34"
+                            "src": "4756:9:34"
                           },
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
-                            "src": "3023:2:34",
+                            "src": "4767:2:34",
                             "type": "",
                             "value": "32"
                           }
@@ -2504,27 +3992,27 @@
                         "functionName": {
                           "name": "add",
                           "nodeType": "YulIdentifier",
-                          "src": "3008:3:34"
+                          "src": "4752:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "3008:18:34"
+                        "src": "4752:18:34"
                       },
                       {
                         "name": "length",
                         "nodeType": "YulIdentifier",
-                        "src": "3028:6:34"
+                        "src": "4772:6:34"
                       }
                     ],
                     "functionName": {
                       "name": "mstore",
                       "nodeType": "YulIdentifier",
-                      "src": "3001:6:34"
+                      "src": "4745:6:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "3001:34:34"
+                    "src": "4745:34:34"
                   },
                   "nodeType": "YulExpressionStatement",
-                  "src": "3001:34:34"
+                  "src": "4745:34:34"
                 },
                 {
                   "expression": {
@@ -2534,12 +4022,12 @@
                           {
                             "name": "value0",
                             "nodeType": "YulIdentifier",
-                            "src": "3070:6:34"
+                            "src": "4814:6:34"
                           },
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
-                            "src": "3078:2:34",
+                            "src": "4822:2:34",
                             "type": "",
                             "value": "32"
                           }
@@ -2547,22 +4035,22 @@
                         "functionName": {
                           "name": "add",
                           "nodeType": "YulIdentifier",
-                          "src": "3066:3:34"
+                          "src": "4810:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "3066:15:34"
+                        "src": "4810:15:34"
                       },
                       {
                         "arguments": [
                           {
                             "name": "headStart",
                             "nodeType": "YulIdentifier",
-                            "src": "3087:9:34"
+                            "src": "4831:9:34"
                           },
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
-                            "src": "3098:2:34",
+                            "src": "4842:2:34",
                             "type": "",
                             "value": "64"
                           }
@@ -2570,31 +4058,31 @@
                         "functionName": {
                           "name": "add",
                           "nodeType": "YulIdentifier",
-                          "src": "3083:3:34"
+                          "src": "4827:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "3083:18:34"
+                        "src": "4827:18:34"
                       },
                       {
                         "name": "length",
                         "nodeType": "YulIdentifier",
-                        "src": "3103:6:34"
+                        "src": "4847:6:34"
                       }
                     ],
                     "functionName": {
                       "name": "copy_memory_to_memory",
                       "nodeType": "YulIdentifier",
-                      "src": "3044:21:34"
+                      "src": "4788:21:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "3044:66:34"
+                    "src": "4788:66:34"
                   },
                   "nodeType": "YulExpressionStatement",
-                  "src": "3044:66:34"
+                  "src": "4788:66:34"
                 },
                 {
                   "nodeType": "YulAssignment",
-                  "src": "3119:62:34",
+                  "src": "4863:62:34",
                   "value": {
                     "arguments": [
                       {
@@ -2602,7 +4090,7 @@
                           {
                             "name": "headStart",
                             "nodeType": "YulIdentifier",
-                            "src": "3135:9:34"
+                            "src": "4879:9:34"
                           },
                           {
                             "arguments": [
@@ -2611,12 +4099,12 @@
                                   {
                                     "name": "length",
                                     "nodeType": "YulIdentifier",
-                                    "src": "3154:6:34"
+                                    "src": "4898:6:34"
                                   },
                                   {
                                     "kind": "number",
                                     "nodeType": "YulLiteral",
-                                    "src": "3162:2:34",
+                                    "src": "4906:2:34",
                                     "type": "",
                                     "value": "31"
                                   }
@@ -2624,17 +4112,17 @@
                                 "functionName": {
                                   "name": "add",
                                   "nodeType": "YulIdentifier",
-                                  "src": "3150:3:34"
+                                  "src": "4894:3:34"
                                 },
                                 "nodeType": "YulFunctionCall",
-                                "src": "3150:15:34"
+                                "src": "4894:15:34"
                               },
                               {
                                 "arguments": [
                                   {
                                     "kind": "number",
                                     "nodeType": "YulLiteral",
-                                    "src": "3171:2:34",
+                                    "src": "4915:2:34",
                                     "type": "",
                                     "value": "31"
                                   }
@@ -2642,33 +4130,33 @@
                                 "functionName": {
                                   "name": "not",
                                   "nodeType": "YulIdentifier",
-                                  "src": "3167:3:34"
+                                  "src": "4911:3:34"
                                 },
                                 "nodeType": "YulFunctionCall",
-                                "src": "3167:7:34"
+                                "src": "4911:7:34"
                               }
                             ],
                             "functionName": {
                               "name": "and",
                               "nodeType": "YulIdentifier",
-                              "src": "3146:3:34"
+                              "src": "4890:3:34"
                             },
                             "nodeType": "YulFunctionCall",
-                            "src": "3146:29:34"
+                            "src": "4890:29:34"
                           }
                         ],
                         "functionName": {
                           "name": "add",
                           "nodeType": "YulIdentifier",
-                          "src": "3131:3:34"
+                          "src": "4875:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "3131:45:34"
+                        "src": "4875:45:34"
                       },
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
-                        "src": "3178:2:34",
+                        "src": "4922:2:34",
                         "type": "",
                         "value": "64"
                       }
@@ -2676,16 +4164,16 @@
                     "functionName": {
                       "name": "add",
                       "nodeType": "YulIdentifier",
-                      "src": "3127:3:34"
+                      "src": "4871:3:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "3127:54:34"
+                    "src": "4871:54:34"
                   },
                   "variableNames": [
                     {
                       "name": "tail",
                       "nodeType": "YulIdentifier",
-                      "src": "3119:4:34"
+                      "src": "4863:4:34"
                     }
                   ]
                 }
@@ -2697,13 +4185,13 @@
               {
                 "name": "headStart",
                 "nodeType": "YulTypedName",
-                "src": "2894:9:34",
+                "src": "4638:9:34",
                 "type": ""
               },
               {
                 "name": "value0",
                 "nodeType": "YulTypedName",
-                "src": "2905:6:34",
+                "src": "4649:6:34",
                 "type": ""
               }
             ],
@@ -2711,16 +4199,16 @@
               {
                 "name": "tail",
                 "nodeType": "YulTypedName",
-                "src": "2916:4:34",
+                "src": "4660:4:34",
                 "type": ""
               }
             ],
-            "src": "2804:383:34"
+            "src": "4548:383:34"
           },
           {
             "body": {
               "nodeType": "YulBlock",
-              "src": "3366:182:34",
+              "src": "5110:182:34",
               "statements": [
                 {
                   "expression": {
@@ -2728,12 +4216,12 @@
                       {
                         "name": "headStart",
                         "nodeType": "YulIdentifier",
-                        "src": "3383:9:34"
+                        "src": "5127:9:34"
                       },
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
-                        "src": "3394:2:34",
+                        "src": "5138:2:34",
                         "type": "",
                         "value": "32"
                       }
@@ -2741,13 +4229,13 @@
                     "functionName": {
                       "name": "mstore",
                       "nodeType": "YulIdentifier",
-                      "src": "3376:6:34"
+                      "src": "5120:6:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "3376:21:34"
+                    "src": "5120:21:34"
                   },
                   "nodeType": "YulExpressionStatement",
-                  "src": "3376:21:34"
+                  "src": "5120:21:34"
                 },
                 {
                   "expression": {
@@ -2757,12 +4245,12 @@
                           {
                             "name": "headStart",
                             "nodeType": "YulIdentifier",
-                            "src": "3417:9:34"
+                            "src": "5161:9:34"
                           },
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
-                            "src": "3428:2:34",
+                            "src": "5172:2:34",
                             "type": "",
                             "value": "32"
                           }
@@ -2770,15 +4258,15 @@
                         "functionName": {
                           "name": "add",
                           "nodeType": "YulIdentifier",
-                          "src": "3413:3:34"
+                          "src": "5157:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "3413:18:34"
+                        "src": "5157:18:34"
                       },
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
-                        "src": "3433:2:34",
+                        "src": "5177:2:34",
                         "type": "",
                         "value": "32"
                       }
@@ -2786,13 +4274,13 @@
                     "functionName": {
                       "name": "mstore",
                       "nodeType": "YulIdentifier",
-                      "src": "3406:6:34"
+                      "src": "5150:6:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "3406:30:34"
+                    "src": "5150:30:34"
                   },
                   "nodeType": "YulExpressionStatement",
-                  "src": "3406:30:34"
+                  "src": "5150:30:34"
                 },
                 {
                   "expression": {
@@ -2802,12 +4290,12 @@
                           {
                             "name": "headStart",
                             "nodeType": "YulIdentifier",
-                            "src": "3456:9:34"
+                            "src": "5200:9:34"
                           },
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
-                            "src": "3467:2:34",
+                            "src": "5211:2:34",
                             "type": "",
                             "value": "64"
                           }
@@ -2815,15 +4303,15 @@
                         "functionName": {
                           "name": "add",
                           "nodeType": "YulIdentifier",
-                          "src": "3452:3:34"
+                          "src": "5196:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "3452:18:34"
+                        "src": "5196:18:34"
                       },
                       {
                         "kind": "string",
                         "nodeType": "YulLiteral",
-                        "src": "3472:34:34",
+                        "src": "5216:34:34",
                         "type": "",
                         "value": "Strings: hex length insufficient"
                       }
@@ -2831,28 +4319,28 @@
                     "functionName": {
                       "name": "mstore",
                       "nodeType": "YulIdentifier",
-                      "src": "3445:6:34"
+                      "src": "5189:6:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "3445:62:34"
+                    "src": "5189:62:34"
                   },
                   "nodeType": "YulExpressionStatement",
-                  "src": "3445:62:34"
+                  "src": "5189:62:34"
                 },
                 {
                   "nodeType": "YulAssignment",
-                  "src": "3516:26:34",
+                  "src": "5260:26:34",
                   "value": {
                     "arguments": [
                       {
                         "name": "headStart",
                         "nodeType": "YulIdentifier",
-                        "src": "3528:9:34"
+                        "src": "5272:9:34"
                       },
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
-                        "src": "3539:2:34",
+                        "src": "5283:2:34",
                         "type": "",
                         "value": "96"
                       }
@@ -2860,16 +4348,16 @@
                     "functionName": {
                       "name": "add",
                       "nodeType": "YulIdentifier",
-                      "src": "3524:3:34"
+                      "src": "5268:3:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "3524:18:34"
+                    "src": "5268:18:34"
                   },
                   "variableNames": [
                     {
                       "name": "tail",
                       "nodeType": "YulIdentifier",
-                      "src": "3516:4:34"
+                      "src": "5260:4:34"
                     }
                   ]
                 }
@@ -2881,7 +4369,7 @@
               {
                 "name": "headStart",
                 "nodeType": "YulTypedName",
-                "src": "3343:9:34",
+                "src": "5087:9:34",
                 "type": ""
               }
             ],
@@ -2889,16 +4377,16 @@
               {
                 "name": "tail",
                 "nodeType": "YulTypedName",
-                "src": "3357:4:34",
+                "src": "5101:4:34",
                 "type": ""
               }
             ],
-            "src": "3192:356:34"
+            "src": "4936:356:34"
           },
           {
             "body": {
               "nodeType": "YulBlock",
-              "src": "3727:237:34",
+              "src": "5471:168:34",
               "statements": [
                 {
                   "expression": {
@@ -2906,12 +4394,12 @@
                       {
                         "name": "headStart",
                         "nodeType": "YulIdentifier",
-                        "src": "3744:9:34"
+                        "src": "5488:9:34"
                       },
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
-                        "src": "3755:2:34",
+                        "src": "5499:2:34",
                         "type": "",
                         "value": "32"
                       }
@@ -2919,13 +4407,13 @@
                     "functionName": {
                       "name": "mstore",
                       "nodeType": "YulIdentifier",
-                      "src": "3737:6:34"
+                      "src": "5481:6:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "3737:21:34"
+                    "src": "5481:21:34"
                   },
                   "nodeType": "YulExpressionStatement",
-                  "src": "3737:21:34"
+                  "src": "5481:21:34"
                 },
                 {
                   "expression": {
@@ -2935,12 +4423,12 @@
                           {
                             "name": "headStart",
                             "nodeType": "YulIdentifier",
-                            "src": "3778:9:34"
+                            "src": "5522:9:34"
                           },
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
-                            "src": "3789:2:34",
+                            "src": "5533:2:34",
                             "type": "",
                             "value": "32"
                           }
@@ -2948,29 +4436,29 @@
                         "functionName": {
                           "name": "add",
                           "nodeType": "YulIdentifier",
-                          "src": "3774:3:34"
+                          "src": "5518:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "3774:18:34"
+                        "src": "5518:18:34"
                       },
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
-                        "src": "3794:2:34",
+                        "src": "5538:2:34",
                         "type": "",
-                        "value": "47"
+                        "value": "18"
                       }
                     ],
                     "functionName": {
                       "name": "mstore",
                       "nodeType": "YulIdentifier",
-                      "src": "3767:6:34"
+                      "src": "5511:6:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "3767:30:34"
+                    "src": "5511:30:34"
                   },
                   "nodeType": "YulExpressionStatement",
-                  "src": "3767:30:34"
+                  "src": "5511:30:34"
                 },
                 {
                   "expression": {
@@ -2980,12 +4468,12 @@
                           {
                             "name": "headStart",
                             "nodeType": "YulIdentifier",
-                            "src": "3817:9:34"
+                            "src": "5561:9:34"
                           },
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
-                            "src": "3828:2:34",
+                            "src": "5572:2:34",
                             "type": "",
                             "value": "64"
                           }
@@ -2993,29 +4481,117 @@
                         "functionName": {
                           "name": "add",
                           "nodeType": "YulIdentifier",
-                          "src": "3813:3:34"
+                          "src": "5557:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "3813:18:34"
+                        "src": "5557:18:34"
                       },
                       {
                         "kind": "string",
                         "nodeType": "YulLiteral",
-                        "src": "3833:34:34",
+                        "src": "5577:20:34",
                         "type": "",
-                        "value": "AccessControl: can only renounce"
+                        "value": "Only current owner"
                       }
                     ],
                     "functionName": {
                       "name": "mstore",
                       "nodeType": "YulIdentifier",
-                      "src": "3806:6:34"
+                      "src": "5550:6:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "3806:62:34"
+                    "src": "5550:48:34"
                   },
                   "nodeType": "YulExpressionStatement",
-                  "src": "3806:62:34"
+                  "src": "5550:48:34"
+                },
+                {
+                  "nodeType": "YulAssignment",
+                  "src": "5607:26:34",
+                  "value": {
+                    "arguments": [
+                      {
+                        "name": "headStart",
+                        "nodeType": "YulIdentifier",
+                        "src": "5619:9:34"
+                      },
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "5630:2:34",
+                        "type": "",
+                        "value": "96"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "add",
+                      "nodeType": "YulIdentifier",
+                      "src": "5615:3:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "5615:18:34"
+                  },
+                  "variableNames": [
+                    {
+                      "name": "tail",
+                      "nodeType": "YulIdentifier",
+                      "src": "5607:4:34"
+                    }
+                  ]
+                }
+              ]
+            },
+            "name": "abi_encode_tuple_t_stringliteral_111b7c5d2b16684041cedd75c064e2306dd9ae18e93fc76a7b5be4886458a40b__to_t_string_memory_ptr__fromStack_reversed",
+            "nodeType": "YulFunctionDefinition",
+            "parameters": [
+              {
+                "name": "headStart",
+                "nodeType": "YulTypedName",
+                "src": "5448:9:34",
+                "type": ""
+              }
+            ],
+            "returnVariables": [
+              {
+                "name": "tail",
+                "nodeType": "YulTypedName",
+                "src": "5462:4:34",
+                "type": ""
+              }
+            ],
+            "src": "5297:342:34"
+          },
+          {
+            "body": {
+              "nodeType": "YulBlock",
+              "src": "5818:161:34",
+              "statements": [
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "name": "headStart",
+                        "nodeType": "YulIdentifier",
+                        "src": "5835:9:34"
+                      },
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "5846:2:34",
+                        "type": "",
+                        "value": "32"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "mstore",
+                      "nodeType": "YulIdentifier",
+                      "src": "5828:6:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "5828:21:34"
+                  },
+                  "nodeType": "YulExpressionStatement",
+                  "src": "5828:21:34"
                 },
                 {
                   "expression": {
@@ -3025,12 +4601,458 @@
                           {
                             "name": "headStart",
                             "nodeType": "YulIdentifier",
-                            "src": "3888:9:34"
+                            "src": "5869:9:34"
                           },
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
-                            "src": "3899:2:34",
+                            "src": "5880:2:34",
+                            "type": "",
+                            "value": "32"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "add",
+                          "nodeType": "YulIdentifier",
+                          "src": "5865:3:34"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "5865:18:34"
+                      },
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "5885:2:34",
+                        "type": "",
+                        "value": "11"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "mstore",
+                      "nodeType": "YulIdentifier",
+                      "src": "5858:6:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "5858:30:34"
+                  },
+                  "nodeType": "YulExpressionStatement",
+                  "src": "5858:30:34"
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "name": "headStart",
+                            "nodeType": "YulIdentifier",
+                            "src": "5908:9:34"
+                          },
+                          {
+                            "kind": "number",
+                            "nodeType": "YulLiteral",
+                            "src": "5919:2:34",
+                            "type": "",
+                            "value": "64"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "add",
+                          "nodeType": "YulIdentifier",
+                          "src": "5904:3:34"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "5904:18:34"
+                      },
+                      {
+                        "kind": "string",
+                        "nodeType": "YulLiteral",
+                        "src": "5924:13:34",
+                        "type": "",
+                        "value": "Only minter"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "mstore",
+                      "nodeType": "YulIdentifier",
+                      "src": "5897:6:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "5897:41:34"
+                  },
+                  "nodeType": "YulExpressionStatement",
+                  "src": "5897:41:34"
+                },
+                {
+                  "nodeType": "YulAssignment",
+                  "src": "5947:26:34",
+                  "value": {
+                    "arguments": [
+                      {
+                        "name": "headStart",
+                        "nodeType": "YulIdentifier",
+                        "src": "5959:9:34"
+                      },
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "5970:2:34",
+                        "type": "",
+                        "value": "96"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "add",
+                      "nodeType": "YulIdentifier",
+                      "src": "5955:3:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "5955:18:34"
+                  },
+                  "variableNames": [
+                    {
+                      "name": "tail",
+                      "nodeType": "YulIdentifier",
+                      "src": "5947:4:34"
+                    }
+                  ]
+                }
+              ]
+            },
+            "name": "abi_encode_tuple_t_stringliteral_578cb4a41adb75340d2cbfbdb0c6610ff4519d15e645cc9b4cc4c64336da99c6__to_t_string_memory_ptr__fromStack_reversed",
+            "nodeType": "YulFunctionDefinition",
+            "parameters": [
+              {
+                "name": "headStart",
+                "nodeType": "YulTypedName",
+                "src": "5795:9:34",
+                "type": ""
+              }
+            ],
+            "returnVariables": [
+              {
+                "name": "tail",
+                "nodeType": "YulTypedName",
+                "src": "5809:4:34",
+                "type": ""
+              }
+            ],
+            "src": "5644:335:34"
+          },
+          {
+            "body": {
+              "nodeType": "YulBlock",
+              "src": "6158:173:34",
+              "statements": [
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "name": "headStart",
+                        "nodeType": "YulIdentifier",
+                        "src": "6175:9:34"
+                      },
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "6186:2:34",
+                        "type": "",
+                        "value": "32"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "mstore",
+                      "nodeType": "YulIdentifier",
+                      "src": "6168:6:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "6168:21:34"
+                  },
+                  "nodeType": "YulExpressionStatement",
+                  "src": "6168:21:34"
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "name": "headStart",
+                            "nodeType": "YulIdentifier",
+                            "src": "6209:9:34"
+                          },
+                          {
+                            "kind": "number",
+                            "nodeType": "YulLiteral",
+                            "src": "6220:2:34",
+                            "type": "",
+                            "value": "32"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "add",
+                          "nodeType": "YulIdentifier",
+                          "src": "6205:3:34"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "6205:18:34"
+                      },
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "6225:2:34",
+                        "type": "",
+                        "value": "23"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "mstore",
+                      "nodeType": "YulIdentifier",
+                      "src": "6198:6:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "6198:30:34"
+                  },
+                  "nodeType": "YulExpressionStatement",
+                  "src": "6198:30:34"
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "name": "headStart",
+                            "nodeType": "YulIdentifier",
+                            "src": "6248:9:34"
+                          },
+                          {
+                            "kind": "number",
+                            "nodeType": "YulLiteral",
+                            "src": "6259:2:34",
+                            "type": "",
+                            "value": "64"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "add",
+                          "nodeType": "YulIdentifier",
+                          "src": "6244:3:34"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "6244:18:34"
+                      },
+                      {
+                        "kind": "string",
+                        "nodeType": "YulLiteral",
+                        "src": "6264:25:34",
+                        "type": "",
+                        "value": "0 is not a valid NFT ID"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "mstore",
+                      "nodeType": "YulIdentifier",
+                      "src": "6237:6:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "6237:53:34"
+                  },
+                  "nodeType": "YulExpressionStatement",
+                  "src": "6237:53:34"
+                },
+                {
+                  "nodeType": "YulAssignment",
+                  "src": "6299:26:34",
+                  "value": {
+                    "arguments": [
+                      {
+                        "name": "headStart",
+                        "nodeType": "YulIdentifier",
+                        "src": "6311:9:34"
+                      },
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "6322:2:34",
+                        "type": "",
+                        "value": "96"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "add",
+                      "nodeType": "YulIdentifier",
+                      "src": "6307:3:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "6307:18:34"
+                  },
+                  "variableNames": [
+                    {
+                      "name": "tail",
+                      "nodeType": "YulIdentifier",
+                      "src": "6299:4:34"
+                    }
+                  ]
+                }
+              ]
+            },
+            "name": "abi_encode_tuple_t_stringliteral_ae13f91217f47fbcc2b0198f394de1f4adce3e41753550c13e2321d5da6b1b56__to_t_string_memory_ptr__fromStack_reversed",
+            "nodeType": "YulFunctionDefinition",
+            "parameters": [
+              {
+                "name": "headStart",
+                "nodeType": "YulTypedName",
+                "src": "6135:9:34",
+                "type": ""
+              }
+            ],
+            "returnVariables": [
+              {
+                "name": "tail",
+                "nodeType": "YulTypedName",
+                "src": "6149:4:34",
+                "type": ""
+              }
+            ],
+            "src": "5984:347:34"
+          },
+          {
+            "body": {
+              "nodeType": "YulBlock",
+              "src": "6510:237:34",
+              "statements": [
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "name": "headStart",
+                        "nodeType": "YulIdentifier",
+                        "src": "6527:9:34"
+                      },
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "6538:2:34",
+                        "type": "",
+                        "value": "32"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "mstore",
+                      "nodeType": "YulIdentifier",
+                      "src": "6520:6:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "6520:21:34"
+                  },
+                  "nodeType": "YulExpressionStatement",
+                  "src": "6520:21:34"
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "name": "headStart",
+                            "nodeType": "YulIdentifier",
+                            "src": "6561:9:34"
+                          },
+                          {
+                            "kind": "number",
+                            "nodeType": "YulLiteral",
+                            "src": "6572:2:34",
+                            "type": "",
+                            "value": "32"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "add",
+                          "nodeType": "YulIdentifier",
+                          "src": "6557:3:34"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "6557:18:34"
+                      },
+                      {
+                        "kind": "number",
+                        "nodeType": "YulLiteral",
+                        "src": "6577:2:34",
+                        "type": "",
+                        "value": "47"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "mstore",
+                      "nodeType": "YulIdentifier",
+                      "src": "6550:6:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "6550:30:34"
+                  },
+                  "nodeType": "YulExpressionStatement",
+                  "src": "6550:30:34"
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "name": "headStart",
+                            "nodeType": "YulIdentifier",
+                            "src": "6600:9:34"
+                          },
+                          {
+                            "kind": "number",
+                            "nodeType": "YulLiteral",
+                            "src": "6611:2:34",
+                            "type": "",
+                            "value": "64"
+                          }
+                        ],
+                        "functionName": {
+                          "name": "add",
+                          "nodeType": "YulIdentifier",
+                          "src": "6596:3:34"
+                        },
+                        "nodeType": "YulFunctionCall",
+                        "src": "6596:18:34"
+                      },
+                      {
+                        "kind": "string",
+                        "nodeType": "YulLiteral",
+                        "src": "6616:34:34",
+                        "type": "",
+                        "value": "AccessControl: can only renounce"
+                      }
+                    ],
+                    "functionName": {
+                      "name": "mstore",
+                      "nodeType": "YulIdentifier",
+                      "src": "6589:6:34"
+                    },
+                    "nodeType": "YulFunctionCall",
+                    "src": "6589:62:34"
+                  },
+                  "nodeType": "YulExpressionStatement",
+                  "src": "6589:62:34"
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "name": "headStart",
+                            "nodeType": "YulIdentifier",
+                            "src": "6671:9:34"
+                          },
+                          {
+                            "kind": "number",
+                            "nodeType": "YulLiteral",
+                            "src": "6682:2:34",
                             "type": "",
                             "value": "96"
                           }
@@ -3038,15 +5060,15 @@
                         "functionName": {
                           "name": "add",
                           "nodeType": "YulIdentifier",
-                          "src": "3884:3:34"
+                          "src": "6667:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "3884:18:34"
+                        "src": "6667:18:34"
                       },
                       {
                         "kind": "string",
                         "nodeType": "YulLiteral",
-                        "src": "3904:17:34",
+                        "src": "6687:17:34",
                         "type": "",
                         "value": " roles for self"
                       }
@@ -3054,28 +5076,28 @@
                     "functionName": {
                       "name": "mstore",
                       "nodeType": "YulIdentifier",
-                      "src": "3877:6:34"
+                      "src": "6660:6:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "3877:45:34"
+                    "src": "6660:45:34"
                   },
                   "nodeType": "YulExpressionStatement",
-                  "src": "3877:45:34"
+                  "src": "6660:45:34"
                 },
                 {
                   "nodeType": "YulAssignment",
-                  "src": "3931:27:34",
+                  "src": "6714:27:34",
                   "value": {
                     "arguments": [
                       {
                         "name": "headStart",
                         "nodeType": "YulIdentifier",
-                        "src": "3943:9:34"
+                        "src": "6726:9:34"
                       },
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
-                        "src": "3954:3:34",
+                        "src": "6737:3:34",
                         "type": "",
                         "value": "128"
                       }
@@ -3083,16 +5105,16 @@
                     "functionName": {
                       "name": "add",
                       "nodeType": "YulIdentifier",
-                      "src": "3939:3:34"
+                      "src": "6722:3:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "3939:19:34"
+                    "src": "6722:19:34"
                   },
                   "variableNames": [
                     {
                       "name": "tail",
                       "nodeType": "YulIdentifier",
-                      "src": "3931:4:34"
+                      "src": "6714:4:34"
                     }
                   ]
                 }
@@ -3104,7 +5126,7 @@
               {
                 "name": "headStart",
                 "nodeType": "YulTypedName",
-                "src": "3704:9:34",
+                "src": "6487:9:34",
                 "type": ""
               }
             ],
@@ -3112,21 +5134,21 @@
               {
                 "name": "tail",
                 "nodeType": "YulTypedName",
-                "src": "3718:4:34",
+                "src": "6501:4:34",
                 "type": ""
               }
             ],
-            "src": "3553:411:34"
+            "src": "6336:411:34"
           },
           {
             "body": {
               "nodeType": "YulBlock",
-              "src": "4017:80:34",
+              "src": "6800:80:34",
               "statements": [
                 {
                   "body": {
                     "nodeType": "YulBlock",
-                    "src": "4044:22:34",
+                    "src": "6827:22:34",
                     "statements": [
                       {
                         "expression": {
@@ -3134,13 +5156,13 @@
                           "functionName": {
                             "name": "panic_error_0x11",
                             "nodeType": "YulIdentifier",
-                            "src": "4046:16:34"
+                            "src": "6829:16:34"
                           },
                           "nodeType": "YulFunctionCall",
-                          "src": "4046:18:34"
+                          "src": "6829:18:34"
                         },
                         "nodeType": "YulExpressionStatement",
-                        "src": "4046:18:34"
+                        "src": "6829:18:34"
                       }
                     ]
                   },
@@ -3149,65 +5171,65 @@
                       {
                         "name": "x",
                         "nodeType": "YulIdentifier",
-                        "src": "4033:1:34"
+                        "src": "6816:1:34"
                       },
                       {
                         "arguments": [
                           {
                             "name": "y",
                             "nodeType": "YulIdentifier",
-                            "src": "4040:1:34"
+                            "src": "6823:1:34"
                           }
                         ],
                         "functionName": {
                           "name": "not",
                           "nodeType": "YulIdentifier",
-                          "src": "4036:3:34"
+                          "src": "6819:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "4036:6:34"
+                        "src": "6819:6:34"
                       }
                     ],
                     "functionName": {
                       "name": "gt",
                       "nodeType": "YulIdentifier",
-                      "src": "4030:2:34"
+                      "src": "6813:2:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "4030:13:34"
+                    "src": "6813:13:34"
                   },
                   "nodeType": "YulIf",
-                  "src": "4027:2:34"
+                  "src": "6810:2:34"
                 },
                 {
                   "nodeType": "YulAssignment",
-                  "src": "4075:16:34",
+                  "src": "6858:16:34",
                   "value": {
                     "arguments": [
                       {
                         "name": "x",
                         "nodeType": "YulIdentifier",
-                        "src": "4086:1:34"
+                        "src": "6869:1:34"
                       },
                       {
                         "name": "y",
                         "nodeType": "YulIdentifier",
-                        "src": "4089:1:34"
+                        "src": "6872:1:34"
                       }
                     ],
                     "functionName": {
                       "name": "add",
                       "nodeType": "YulIdentifier",
-                      "src": "4082:3:34"
+                      "src": "6865:3:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "4082:9:34"
+                    "src": "6865:9:34"
                   },
                   "variableNames": [
                     {
                       "name": "sum",
                       "nodeType": "YulIdentifier",
-                      "src": "4075:3:34"
+                      "src": "6858:3:34"
                     }
                   ]
                 }
@@ -3219,13 +5241,13 @@
               {
                 "name": "x",
                 "nodeType": "YulTypedName",
-                "src": "4000:1:34",
+                "src": "6783:1:34",
                 "type": ""
               },
               {
                 "name": "y",
                 "nodeType": "YulTypedName",
-                "src": "4003:1:34",
+                "src": "6786:1:34",
                 "type": ""
               }
             ],
@@ -3233,21 +5255,21 @@
               {
                 "name": "sum",
                 "nodeType": "YulTypedName",
-                "src": "4009:3:34",
+                "src": "6792:3:34",
                 "type": ""
               }
             ],
-            "src": "3969:128:34"
+            "src": "6752:128:34"
           },
           {
             "body": {
               "nodeType": "YulBlock",
-              "src": "4154:116:34",
+              "src": "6937:116:34",
               "statements": [
                 {
                   "body": {
                     "nodeType": "YulBlock",
-                    "src": "4213:22:34",
+                    "src": "6996:22:34",
                     "statements": [
                       {
                         "expression": {
@@ -3255,13 +5277,13 @@
                           "functionName": {
                             "name": "panic_error_0x11",
                             "nodeType": "YulIdentifier",
-                            "src": "4215:16:34"
+                            "src": "6998:16:34"
                           },
                           "nodeType": "YulFunctionCall",
-                          "src": "4215:18:34"
+                          "src": "6998:18:34"
                         },
                         "nodeType": "YulExpressionStatement",
-                        "src": "4215:18:34"
+                        "src": "6998:18:34"
                       }
                     ]
                   },
@@ -3274,32 +5296,32 @@
                               {
                                 "name": "x",
                                 "nodeType": "YulIdentifier",
-                                "src": "4185:1:34"
+                                "src": "6968:1:34"
                               }
                             ],
                             "functionName": {
                               "name": "iszero",
                               "nodeType": "YulIdentifier",
-                              "src": "4178:6:34"
+                              "src": "6961:6:34"
                             },
                             "nodeType": "YulFunctionCall",
-                            "src": "4178:9:34"
+                            "src": "6961:9:34"
                           }
                         ],
                         "functionName": {
                           "name": "iszero",
                           "nodeType": "YulIdentifier",
-                          "src": "4171:6:34"
+                          "src": "6954:6:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "4171:17:34"
+                        "src": "6954:17:34"
                       },
                       {
                         "arguments": [
                           {
                             "name": "y",
                             "nodeType": "YulIdentifier",
-                            "src": "4193:1:34"
+                            "src": "6976:1:34"
                           },
                           {
                             "arguments": [
@@ -3308,7 +5330,7 @@
                                   {
                                     "kind": "number",
                                     "nodeType": "YulLiteral",
-                                    "src": "4204:1:34",
+                                    "src": "6987:1:34",
                                     "type": "",
                                     "value": "0"
                                   }
@@ -3316,75 +5338,75 @@
                                 "functionName": {
                                   "name": "not",
                                   "nodeType": "YulIdentifier",
-                                  "src": "4200:3:34"
+                                  "src": "6983:3:34"
                                 },
                                 "nodeType": "YulFunctionCall",
-                                "src": "4200:6:34"
+                                "src": "6983:6:34"
                               },
                               {
                                 "name": "x",
                                 "nodeType": "YulIdentifier",
-                                "src": "4208:1:34"
+                                "src": "6991:1:34"
                               }
                             ],
                             "functionName": {
                               "name": "div",
                               "nodeType": "YulIdentifier",
-                              "src": "4196:3:34"
+                              "src": "6979:3:34"
                             },
                             "nodeType": "YulFunctionCall",
-                            "src": "4196:14:34"
+                            "src": "6979:14:34"
                           }
                         ],
                         "functionName": {
                           "name": "gt",
                           "nodeType": "YulIdentifier",
-                          "src": "4190:2:34"
+                          "src": "6973:2:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "4190:21:34"
+                        "src": "6973:21:34"
                       }
                     ],
                     "functionName": {
                       "name": "and",
                       "nodeType": "YulIdentifier",
-                      "src": "4167:3:34"
+                      "src": "6950:3:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "4167:45:34"
+                    "src": "6950:45:34"
                   },
                   "nodeType": "YulIf",
-                  "src": "4164:2:34"
+                  "src": "6947:2:34"
                 },
                 {
                   "nodeType": "YulAssignment",
-                  "src": "4244:20:34",
+                  "src": "7027:20:34",
                   "value": {
                     "arguments": [
                       {
                         "name": "x",
                         "nodeType": "YulIdentifier",
-                        "src": "4259:1:34"
+                        "src": "7042:1:34"
                       },
                       {
                         "name": "y",
                         "nodeType": "YulIdentifier",
-                        "src": "4262:1:34"
+                        "src": "7045:1:34"
                       }
                     ],
                     "functionName": {
                       "name": "mul",
                       "nodeType": "YulIdentifier",
-                      "src": "4255:3:34"
+                      "src": "7038:3:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "4255:9:34"
+                    "src": "7038:9:34"
                   },
                   "variableNames": [
                     {
                       "name": "product",
                       "nodeType": "YulIdentifier",
-                      "src": "4244:7:34"
+                      "src": "7027:7:34"
                     }
                   ]
                 }
@@ -3396,13 +5418,13 @@
               {
                 "name": "x",
                 "nodeType": "YulTypedName",
-                "src": "4133:1:34",
+                "src": "6916:1:34",
                 "type": ""
               },
               {
                 "name": "y",
                 "nodeType": "YulTypedName",
-                "src": "4136:1:34",
+                "src": "6919:1:34",
                 "type": ""
               }
             ],
@@ -3410,24 +5432,24 @@
               {
                 "name": "product",
                 "nodeType": "YulTypedName",
-                "src": "4142:7:34",
+                "src": "6925:7:34",
                 "type": ""
               }
             ],
-            "src": "4102:168:34"
+            "src": "6885:168:34"
           },
           {
             "body": {
               "nodeType": "YulBlock",
-              "src": "4328:205:34",
+              "src": "7111:205:34",
               "statements": [
                 {
                   "nodeType": "YulVariableDeclaration",
-                  "src": "4338:10:34",
+                  "src": "7121:10:34",
                   "value": {
                     "kind": "number",
                     "nodeType": "YulLiteral",
-                    "src": "4347:1:34",
+                    "src": "7130:1:34",
                     "type": "",
                     "value": "0"
                   },
@@ -3435,7 +5457,7 @@
                     {
                       "name": "i",
                       "nodeType": "YulTypedName",
-                      "src": "4342:1:34",
+                      "src": "7125:1:34",
                       "type": ""
                     }
                   ]
@@ -3443,7 +5465,7 @@
                 {
                   "body": {
                     "nodeType": "YulBlock",
-                    "src": "4407:63:34",
+                    "src": "7190:63:34",
                     "statements": [
                       {
                         "expression": {
@@ -3453,21 +5475,21 @@
                                 {
                                   "name": "dst",
                                   "nodeType": "YulIdentifier",
-                                  "src": "4432:3:34"
+                                  "src": "7215:3:34"
                                 },
                                 {
                                   "name": "i",
                                   "nodeType": "YulIdentifier",
-                                  "src": "4437:1:34"
+                                  "src": "7220:1:34"
                                 }
                               ],
                               "functionName": {
                                 "name": "add",
                                 "nodeType": "YulIdentifier",
-                                "src": "4428:3:34"
+                                "src": "7211:3:34"
                               },
                               "nodeType": "YulFunctionCall",
-                              "src": "4428:11:34"
+                              "src": "7211:11:34"
                             },
                             {
                               "arguments": [
@@ -3476,42 +5498,42 @@
                                     {
                                       "name": "src",
                                       "nodeType": "YulIdentifier",
-                                      "src": "4451:3:34"
+                                      "src": "7234:3:34"
                                     },
                                     {
                                       "name": "i",
                                       "nodeType": "YulIdentifier",
-                                      "src": "4456:1:34"
+                                      "src": "7239:1:34"
                                     }
                                   ],
                                   "functionName": {
                                     "name": "add",
                                     "nodeType": "YulIdentifier",
-                                    "src": "4447:3:34"
+                                    "src": "7230:3:34"
                                   },
                                   "nodeType": "YulFunctionCall",
-                                  "src": "4447:11:34"
+                                  "src": "7230:11:34"
                                 }
                               ],
                               "functionName": {
                                 "name": "mload",
                                 "nodeType": "YulIdentifier",
-                                "src": "4441:5:34"
+                                "src": "7224:5:34"
                               },
                               "nodeType": "YulFunctionCall",
-                              "src": "4441:18:34"
+                              "src": "7224:18:34"
                             }
                           ],
                           "functionName": {
                             "name": "mstore",
                             "nodeType": "YulIdentifier",
-                            "src": "4421:6:34"
+                            "src": "7204:6:34"
                           },
                           "nodeType": "YulFunctionCall",
-                          "src": "4421:39:34"
+                          "src": "7204:39:34"
                         },
                         "nodeType": "YulExpressionStatement",
-                        "src": "4421:39:34"
+                        "src": "7204:39:34"
                       }
                     ]
                   },
@@ -3520,41 +5542,41 @@
                       {
                         "name": "i",
                         "nodeType": "YulIdentifier",
-                        "src": "4368:1:34"
+                        "src": "7151:1:34"
                       },
                       {
                         "name": "length",
                         "nodeType": "YulIdentifier",
-                        "src": "4371:6:34"
+                        "src": "7154:6:34"
                       }
                     ],
                     "functionName": {
                       "name": "lt",
                       "nodeType": "YulIdentifier",
-                      "src": "4365:2:34"
+                      "src": "7148:2:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "4365:13:34"
+                    "src": "7148:13:34"
                   },
                   "nodeType": "YulForLoop",
                   "post": {
                     "nodeType": "YulBlock",
-                    "src": "4379:19:34",
+                    "src": "7162:19:34",
                     "statements": [
                       {
                         "nodeType": "YulAssignment",
-                        "src": "4381:15:34",
+                        "src": "7164:15:34",
                         "value": {
                           "arguments": [
                             {
                               "name": "i",
                               "nodeType": "YulIdentifier",
-                              "src": "4390:1:34"
+                              "src": "7173:1:34"
                             },
                             {
                               "kind": "number",
                               "nodeType": "YulLiteral",
-                              "src": "4393:2:34",
+                              "src": "7176:2:34",
                               "type": "",
                               "value": "32"
                             }
@@ -3562,16 +5584,16 @@
                           "functionName": {
                             "name": "add",
                             "nodeType": "YulIdentifier",
-                            "src": "4386:3:34"
+                            "src": "7169:3:34"
                           },
                           "nodeType": "YulFunctionCall",
-                          "src": "4386:10:34"
+                          "src": "7169:10:34"
                         },
                         "variableNames": [
                           {
                             "name": "i",
                             "nodeType": "YulIdentifier",
-                            "src": "4381:1:34"
+                            "src": "7164:1:34"
                           }
                         ]
                       }
@@ -3579,15 +5601,15 @@
                   },
                   "pre": {
                     "nodeType": "YulBlock",
-                    "src": "4361:3:34",
+                    "src": "7144:3:34",
                     "statements": []
                   },
-                  "src": "4357:113:34"
+                  "src": "7140:113:34"
                 },
                 {
                   "body": {
                     "nodeType": "YulBlock",
-                    "src": "4496:31:34",
+                    "src": "7279:31:34",
                     "statements": [
                       {
                         "expression": {
@@ -3597,26 +5619,26 @@
                                 {
                                   "name": "dst",
                                   "nodeType": "YulIdentifier",
-                                  "src": "4509:3:34"
+                                  "src": "7292:3:34"
                                 },
                                 {
                                   "name": "length",
                                   "nodeType": "YulIdentifier",
-                                  "src": "4514:6:34"
+                                  "src": "7297:6:34"
                                 }
                               ],
                               "functionName": {
                                 "name": "add",
                                 "nodeType": "YulIdentifier",
-                                "src": "4505:3:34"
+                                "src": "7288:3:34"
                               },
                               "nodeType": "YulFunctionCall",
-                              "src": "4505:16:34"
+                              "src": "7288:16:34"
                             },
                             {
                               "kind": "number",
                               "nodeType": "YulLiteral",
-                              "src": "4523:1:34",
+                              "src": "7306:1:34",
                               "type": "",
                               "value": "0"
                             }
@@ -3624,13 +5646,13 @@
                           "functionName": {
                             "name": "mstore",
                             "nodeType": "YulIdentifier",
-                            "src": "4498:6:34"
+                            "src": "7281:6:34"
                           },
                           "nodeType": "YulFunctionCall",
-                          "src": "4498:27:34"
+                          "src": "7281:27:34"
                         },
                         "nodeType": "YulExpressionStatement",
-                        "src": "4498:27:34"
+                        "src": "7281:27:34"
                       }
                     ]
                   },
@@ -3639,24 +5661,24 @@
                       {
                         "name": "i",
                         "nodeType": "YulIdentifier",
-                        "src": "4485:1:34"
+                        "src": "7268:1:34"
                       },
                       {
                         "name": "length",
                         "nodeType": "YulIdentifier",
-                        "src": "4488:6:34"
+                        "src": "7271:6:34"
                       }
                     ],
                     "functionName": {
                       "name": "gt",
                       "nodeType": "YulIdentifier",
-                      "src": "4482:2:34"
+                      "src": "7265:2:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "4482:13:34"
+                    "src": "7265:13:34"
                   },
                   "nodeType": "YulIf",
-                  "src": "4479:2:34"
+                  "src": "7262:2:34"
                 }
               ]
             },
@@ -3666,33 +5688,33 @@
               {
                 "name": "src",
                 "nodeType": "YulTypedName",
-                "src": "4306:3:34",
+                "src": "7089:3:34",
                 "type": ""
               },
               {
                 "name": "dst",
                 "nodeType": "YulTypedName",
-                "src": "4311:3:34",
+                "src": "7094:3:34",
                 "type": ""
               },
               {
                 "name": "length",
                 "nodeType": "YulTypedName",
-                "src": "4316:6:34",
+                "src": "7099:6:34",
                 "type": ""
               }
             ],
-            "src": "4275:258:34"
+            "src": "7058:258:34"
           },
           {
             "body": {
               "nodeType": "YulBlock",
-              "src": "4585:89:34",
+              "src": "7368:89:34",
               "statements": [
                 {
                   "body": {
                     "nodeType": "YulBlock",
-                    "src": "4612:22:34",
+                    "src": "7395:22:34",
                     "statements": [
                       {
                         "expression": {
@@ -3700,13 +5722,13 @@
                           "functionName": {
                             "name": "panic_error_0x11",
                             "nodeType": "YulIdentifier",
-                            "src": "4614:16:34"
+                            "src": "7397:16:34"
                           },
                           "nodeType": "YulFunctionCall",
-                          "src": "4614:18:34"
+                          "src": "7397:18:34"
                         },
                         "nodeType": "YulExpressionStatement",
-                        "src": "4614:18:34"
+                        "src": "7397:18:34"
                       }
                     ]
                   },
@@ -3715,36 +5737,36 @@
                       {
                         "name": "value",
                         "nodeType": "YulIdentifier",
-                        "src": "4605:5:34"
+                        "src": "7388:5:34"
                       }
                     ],
                     "functionName": {
                       "name": "iszero",
                       "nodeType": "YulIdentifier",
-                      "src": "4598:6:34"
+                      "src": "7381:6:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "4598:13:34"
+                    "src": "7381:13:34"
                   },
                   "nodeType": "YulIf",
-                  "src": "4595:2:34"
+                  "src": "7378:2:34"
                 },
                 {
                   "nodeType": "YulAssignment",
-                  "src": "4643:25:34",
+                  "src": "7426:25:34",
                   "value": {
                     "arguments": [
                       {
                         "name": "value",
                         "nodeType": "YulIdentifier",
-                        "src": "4654:5:34"
+                        "src": "7437:5:34"
                       },
                       {
                         "arguments": [
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
-                            "src": "4665:1:34",
+                            "src": "7448:1:34",
                             "type": "",
                             "value": "0"
                           }
@@ -3752,25 +5774,25 @@
                         "functionName": {
                           "name": "not",
                           "nodeType": "YulIdentifier",
-                          "src": "4661:3:34"
+                          "src": "7444:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "4661:6:34"
+                        "src": "7444:6:34"
                       }
                     ],
                     "functionName": {
                       "name": "add",
                       "nodeType": "YulIdentifier",
-                      "src": "4650:3:34"
+                      "src": "7433:3:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "4650:18:34"
+                    "src": "7433:18:34"
                   },
                   "variableNames": [
                     {
                       "name": "ret",
                       "nodeType": "YulIdentifier",
-                      "src": "4643:3:34"
+                      "src": "7426:3:34"
                     }
                   ]
                 }
@@ -3782,7 +5804,7 @@
               {
                 "name": "value",
                 "nodeType": "YulTypedName",
-                "src": "4567:5:34",
+                "src": "7350:5:34",
                 "type": ""
               }
             ],
@@ -3790,16 +5812,16 @@
               {
                 "name": "ret",
                 "nodeType": "YulTypedName",
-                "src": "4577:3:34",
+                "src": "7360:3:34",
                 "type": ""
               }
             ],
-            "src": "4538:136:34"
+            "src": "7321:136:34"
           },
           {
             "body": {
               "nodeType": "YulBlock",
-              "src": "4711:95:34",
+              "src": "7494:95:34",
               "statements": [
                 {
                   "expression": {
@@ -3807,7 +5829,7 @@
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
-                        "src": "4728:1:34",
+                        "src": "7511:1:34",
                         "type": "",
                         "value": "0"
                       },
@@ -3816,14 +5838,14 @@
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
-                            "src": "4735:3:34",
+                            "src": "7518:3:34",
                             "type": "",
                             "value": "224"
                           },
                           {
                             "kind": "number",
                             "nodeType": "YulLiteral",
-                            "src": "4740:10:34",
+                            "src": "7523:10:34",
                             "type": "",
                             "value": "0x4e487b71"
                           }
@@ -3831,22 +5853,22 @@
                         "functionName": {
                           "name": "shl",
                           "nodeType": "YulIdentifier",
-                          "src": "4731:3:34"
+                          "src": "7514:3:34"
                         },
                         "nodeType": "YulFunctionCall",
-                        "src": "4731:20:34"
+                        "src": "7514:20:34"
                       }
                     ],
                     "functionName": {
                       "name": "mstore",
                       "nodeType": "YulIdentifier",
-                      "src": "4721:6:34"
+                      "src": "7504:6:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "4721:31:34"
+                    "src": "7504:31:34"
                   },
                   "nodeType": "YulExpressionStatement",
-                  "src": "4721:31:34"
+                  "src": "7504:31:34"
                 },
                 {
                   "expression": {
@@ -3854,14 +5876,14 @@
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
-                        "src": "4768:1:34",
+                        "src": "7551:1:34",
                         "type": "",
                         "value": "4"
                       },
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
-                        "src": "4771:4:34",
+                        "src": "7554:4:34",
                         "type": "",
                         "value": "0x11"
                       }
@@ -3869,13 +5891,13 @@
                     "functionName": {
                       "name": "mstore",
                       "nodeType": "YulIdentifier",
-                      "src": "4761:6:34"
+                      "src": "7544:6:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "4761:15:34"
+                    "src": "7544:15:34"
                   },
                   "nodeType": "YulExpressionStatement",
-                  "src": "4761:15:34"
+                  "src": "7544:15:34"
                 },
                 {
                   "expression": {
@@ -3883,14 +5905,14 @@
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
-                        "src": "4792:1:34",
+                        "src": "7575:1:34",
                         "type": "",
                         "value": "0"
                       },
                       {
                         "kind": "number",
                         "nodeType": "YulLiteral",
-                        "src": "4795:4:34",
+                        "src": "7578:4:34",
                         "type": "",
                         "value": "0x24"
                       }
@@ -3898,61 +5920,106 @@
                     "functionName": {
                       "name": "revert",
                       "nodeType": "YulIdentifier",
-                      "src": "4785:6:34"
+                      "src": "7568:6:34"
                     },
                     "nodeType": "YulFunctionCall",
-                    "src": "4785:15:34"
+                    "src": "7568:15:34"
                   },
                   "nodeType": "YulExpressionStatement",
-                  "src": "4785:15:34"
+                  "src": "7568:15:34"
                 }
               ]
             },
             "name": "panic_error_0x11",
             "nodeType": "YulFunctionDefinition",
-            "src": "4679:127:34"
+            "src": "7462:127:34"
           }
         ]
       },
-      "contents": "{\n    { }\n    function abi_decode_address(offset) -> value\n    {\n        value := calldataload(offset)\n        if iszero(eq(value, and(value, sub(shl(160, 1), 1)))) { revert(0, 0) }\n    }\n    function abi_decode_tuple_t_address(headStart, dataEnd) -> value0\n    {\n        if slt(sub(dataEnd, headStart), 32) { revert(value0, value0) }\n        value0 := abi_decode_address(headStart)\n    }\n    function abi_decode_tuple_t_bytes32(headStart, dataEnd) -> value0\n    {\n        if slt(sub(dataEnd, headStart), 32) { revert(value0, value0) }\n        value0 := calldataload(headStart)\n    }\n    function abi_decode_tuple_t_bytes32t_address(headStart, dataEnd) -> value0, value1\n    {\n        if slt(sub(dataEnd, headStart), 64) { revert(value1, value1) }\n        value0 := calldataload(headStart)\n        value1 := abi_decode_address(add(headStart, 32))\n    }\n    function abi_decode_tuple_t_bytes4(headStart, dataEnd) -> value0\n    {\n        if slt(sub(dataEnd, headStart), 32) { revert(value0, value0) }\n        let value := calldataload(headStart)\n        if iszero(eq(value, and(value, shl(224, 0xffffffff)))) { revert(value0, value0) }\n        value0 := value\n    }\n    function abi_decode_tuple_t_uint256t_bytes32(headStart, dataEnd) -> value0, value1\n    {\n        if slt(sub(dataEnd, headStart), 64) { revert(value0, value0) }\n        value0 := calldataload(headStart)\n        value1 := calldataload(add(headStart, 32))\n    }\n    function abi_encode_tuple_packed_t_stringliteral_da0d07ce4a2849fbfc4cb9d6f939e9bd93016c372ca4a5ff14fe06caf3d67874_t_string_memory_ptr_t_stringliteral_f986ce851518a691bccd44ea42a5a185d1b866ef6cb07984a09b81694d20ab69_t_string_memory_ptr__to_t_string_memory_ptr_t_string_memory_ptr_t_string_memory_ptr_t_string_memory_ptr__nonPadded_inplace_fromStack_reversed(pos, value1, value0) -> end\n    {\n        mstore(pos, \"AccessControl: account \")\n        let length := mload(value0)\n        copy_memory_to_memory(add(value0, 0x20), add(pos, 23), length)\n        let _1 := add(pos, length)\n        mstore(add(_1, 23), \" is missing role \")\n        let length_1 := mload(value1)\n        copy_memory_to_memory(add(value1, 0x20), add(_1, 40), length_1)\n        end := add(add(_1, length_1), 40)\n    }\n    function abi_encode_tuple_t_address__to_t_address__fromStack_reversed(headStart, value0) -> tail\n    {\n        tail := add(headStart, 32)\n        mstore(headStart, and(value0, sub(shl(160, 1), 1)))\n    }\n    function abi_encode_tuple_t_bool__to_t_bool__fromStack_reversed(headStart, value0) -> tail\n    {\n        tail := add(headStart, 32)\n        mstore(headStart, iszero(iszero(value0)))\n    }\n    function abi_encode_tuple_t_bytes32__to_t_bytes32__fromStack_reversed(headStart, value0) -> tail\n    {\n        tail := add(headStart, 32)\n        mstore(headStart, value0)\n    }\n    function abi_encode_tuple_t_string_memory_ptr__to_t_string_memory_ptr__fromStack_reversed(headStart, value0) -> tail\n    {\n        mstore(headStart, 32)\n        let length := mload(value0)\n        mstore(add(headStart, 32), length)\n        copy_memory_to_memory(add(value0, 32), add(headStart, 64), length)\n        tail := add(add(headStart, and(add(length, 31), not(31))), 64)\n    }\n    function abi_encode_tuple_t_stringliteral_04fc88320d7c9f639317c75102c103ff0044d3075a5c627e24e76e5bbb2733c2__to_t_string_memory_ptr__fromStack_reversed(headStart) -> tail\n    {\n        mstore(headStart, 32)\n        mstore(add(headStart, 32), 32)\n        mstore(add(headStart, 64), \"Strings: hex length insufficient\")\n        tail := add(headStart, 96)\n    }\n    function abi_encode_tuple_t_stringliteral_fb06fa8ff2141e8ed74502f6792273793f25f0e9d3cf15344f3f5a0d4948fd4b__to_t_string_memory_ptr__fromStack_reversed(headStart) -> tail\n    {\n        mstore(headStart, 32)\n        mstore(add(headStart, 32), 47)\n        mstore(add(headStart, 64), \"AccessControl: can only renounce\")\n        mstore(add(headStart, 96), \" roles for self\")\n        tail := add(headStart, 128)\n    }\n    function checked_add_t_uint256(x, y) -> sum\n    {\n        if gt(x, not(y)) { panic_error_0x11() }\n        sum := add(x, y)\n    }\n    function checked_mul_t_uint256(x, y) -> product\n    {\n        if and(iszero(iszero(x)), gt(y, div(not(0), x))) { panic_error_0x11() }\n        product := mul(x, y)\n    }\n    function copy_memory_to_memory(src, dst, length)\n    {\n        let i := 0\n        for { } lt(i, length) { i := add(i, 32) }\n        {\n            mstore(add(dst, i), mload(add(src, i)))\n        }\n        if gt(i, length) { mstore(add(dst, length), 0) }\n    }\n    function decrement_t_uint256(value) -> ret\n    {\n        if iszero(value) { panic_error_0x11() }\n        ret := add(value, not(0))\n    }\n    function panic_error_0x11()\n    {\n        mstore(0, shl(224, 0x4e487b71))\n        mstore(4, 0x11)\n        revert(0, 0x24)\n    }\n}",
+      "contents": "{\n    { }\n    function abi_decode_address(offset) -> value\n    {\n        value := calldataload(offset)\n        if iszero(eq(value, and(value, sub(shl(160, 1), 1)))) { revert(0, 0) }\n    }\n    function abi_decode_tuple_t_address(headStart, dataEnd) -> value0\n    {\n        if slt(sub(dataEnd, headStart), 32) { revert(value0, value0) }\n        value0 := abi_decode_address(headStart)\n    }\n    function abi_decode_tuple_t_bytes32(headStart, dataEnd) -> value0\n    {\n        if slt(sub(dataEnd, headStart), 32) { revert(value0, value0) }\n        value0 := calldataload(headStart)\n    }\n    function abi_decode_tuple_t_bytes32t_address(headStart, dataEnd) -> value0, value1\n    {\n        if slt(sub(dataEnd, headStart), 64) { revert(value1, value1) }\n        value0 := calldataload(headStart)\n        value1 := abi_decode_address(add(headStart, 32))\n    }\n    function abi_decode_tuple_t_bytes4(headStart, dataEnd) -> value0\n    {\n        if slt(sub(dataEnd, headStart), 32) { revert(value0, value0) }\n        let value := calldataload(headStart)\n        if iszero(eq(value, and(value, shl(224, 0xffffffff)))) { revert(value0, value0) }\n        value0 := value\n    }\n    function abi_decode_tuple_t_uint256(headStart, dataEnd) -> value0\n    {\n        if slt(sub(dataEnd, headStart), 32) { revert(value0, value0) }\n        value0 := calldataload(headStart)\n    }\n    function abi_decode_tuple_t_uint256_fromMemory(headStart, dataEnd) -> value0\n    {\n        if slt(sub(dataEnd, headStart), 32) { revert(value0, value0) }\n        value0 := mload(headStart)\n    }\n    function abi_decode_tuple_t_uint256t_bytes_calldata_ptr(headStart, dataEnd) -> value0, value1, value2\n    {\n        if slt(sub(dataEnd, headStart), 64) { revert(value2, value2) }\n        value0 := calldataload(headStart)\n        let offset := calldataload(add(headStart, 32))\n        let _1 := sub(shl(64, 1), 1)\n        if gt(offset, _1) { revert(value2, value2) }\n        let _2 := add(headStart, offset)\n        if iszero(slt(add(_2, 0x1f), dataEnd)) { revert(value2, value2) }\n        let length := calldataload(_2)\n        if gt(length, _1) { revert(value2, value2) }\n        if gt(add(add(_2, length), 32), dataEnd) { revert(value2, value2) }\n        value1 := add(_2, 32)\n        value2 := length\n    }\n    function abi_encode_tuple_packed_t_stringliteral_da0d07ce4a2849fbfc4cb9d6f939e9bd93016c372ca4a5ff14fe06caf3d67874_t_string_memory_ptr_t_stringliteral_f986ce851518a691bccd44ea42a5a185d1b866ef6cb07984a09b81694d20ab69_t_string_memory_ptr__to_t_string_memory_ptr_t_string_memory_ptr_t_string_memory_ptr_t_string_memory_ptr__nonPadded_inplace_fromStack_reversed(pos, value1, value0) -> end\n    {\n        mstore(pos, \"AccessControl: account \")\n        let length := mload(value0)\n        copy_memory_to_memory(add(value0, 0x20), add(pos, 23), length)\n        let _1 := add(pos, length)\n        mstore(add(_1, 23), \" is missing role \")\n        let length_1 := mload(value1)\n        copy_memory_to_memory(add(value1, 0x20), add(_1, 40), length_1)\n        end := add(add(_1, length_1), 40)\n    }\n    function abi_encode_tuple_t_address__to_t_address__fromStack_reversed(headStart, value0) -> tail\n    {\n        tail := add(headStart, 32)\n        mstore(headStart, and(value0, sub(shl(160, 1), 1)))\n    }\n    function abi_encode_tuple_t_address_t_uint256__to_t_address_t_uint256__fromStack_reversed(headStart, value1, value0) -> tail\n    {\n        tail := add(headStart, 64)\n        mstore(headStart, and(value0, sub(shl(160, 1), 1)))\n        mstore(add(headStart, 32), value1)\n    }\n    function abi_encode_tuple_t_bool__to_t_bool__fromStack_reversed(headStart, value0) -> tail\n    {\n        tail := add(headStart, 32)\n        mstore(headStart, iszero(iszero(value0)))\n    }\n    function abi_encode_tuple_t_bytes32__to_t_bytes32__fromStack_reversed(headStart, value0) -> tail\n    {\n        tail := add(headStart, 32)\n        mstore(headStart, value0)\n    }\n    function abi_encode_tuple_t_bytes_calldata_ptr__to_t_bytes_memory_ptr__fromStack_reversed(headStart, value1, value0) -> tail\n    {\n        mstore(headStart, 32)\n        mstore(add(headStart, 32), value1)\n        calldatacopy(add(headStart, 64), value0, value1)\n        mstore(add(add(headStart, value1), 64), tail)\n        tail := add(add(headStart, and(add(value1, 31), not(31))), 64)\n    }\n    function abi_encode_tuple_t_contract$_Freeport_$947__to_t_address__fromStack_reversed(headStart, value0) -> tail\n    {\n        tail := add(headStart, 32)\n        mstore(headStart, and(value0, sub(shl(160, 1), 1)))\n    }\n    function abi_encode_tuple_t_string_memory_ptr__to_t_string_memory_ptr__fromStack_reversed(headStart, value0) -> tail\n    {\n        mstore(headStart, 32)\n        let length := mload(value0)\n        mstore(add(headStart, 32), length)\n        copy_memory_to_memory(add(value0, 32), add(headStart, 64), length)\n        tail := add(add(headStart, and(add(length, 31), not(31))), 64)\n    }\n    function abi_encode_tuple_t_stringliteral_04fc88320d7c9f639317c75102c103ff0044d3075a5c627e24e76e5bbb2733c2__to_t_string_memory_ptr__fromStack_reversed(headStart) -> tail\n    {\n        mstore(headStart, 32)\n        mstore(add(headStart, 32), 32)\n        mstore(add(headStart, 64), \"Strings: hex length insufficient\")\n        tail := add(headStart, 96)\n    }\n    function abi_encode_tuple_t_stringliteral_111b7c5d2b16684041cedd75c064e2306dd9ae18e93fc76a7b5be4886458a40b__to_t_string_memory_ptr__fromStack_reversed(headStart) -> tail\n    {\n        mstore(headStart, 32)\n        mstore(add(headStart, 32), 18)\n        mstore(add(headStart, 64), \"Only current owner\")\n        tail := add(headStart, 96)\n    }\n    function abi_encode_tuple_t_stringliteral_578cb4a41adb75340d2cbfbdb0c6610ff4519d15e645cc9b4cc4c64336da99c6__to_t_string_memory_ptr__fromStack_reversed(headStart) -> tail\n    {\n        mstore(headStart, 32)\n        mstore(add(headStart, 32), 11)\n        mstore(add(headStart, 64), \"Only minter\")\n        tail := add(headStart, 96)\n    }\n    function abi_encode_tuple_t_stringliteral_ae13f91217f47fbcc2b0198f394de1f4adce3e41753550c13e2321d5da6b1b56__to_t_string_memory_ptr__fromStack_reversed(headStart) -> tail\n    {\n        mstore(headStart, 32)\n        mstore(add(headStart, 32), 23)\n        mstore(add(headStart, 64), \"0 is not a valid NFT ID\")\n        tail := add(headStart, 96)\n    }\n    function abi_encode_tuple_t_stringliteral_fb06fa8ff2141e8ed74502f6792273793f25f0e9d3cf15344f3f5a0d4948fd4b__to_t_string_memory_ptr__fromStack_reversed(headStart) -> tail\n    {\n        mstore(headStart, 32)\n        mstore(add(headStart, 32), 47)\n        mstore(add(headStart, 64), \"AccessControl: can only renounce\")\n        mstore(add(headStart, 96), \" roles for self\")\n        tail := add(headStart, 128)\n    }\n    function checked_add_t_uint256(x, y) -> sum\n    {\n        if gt(x, not(y)) { panic_error_0x11() }\n        sum := add(x, y)\n    }\n    function checked_mul_t_uint256(x, y) -> product\n    {\n        if and(iszero(iszero(x)), gt(y, div(not(0), x))) { panic_error_0x11() }\n        product := mul(x, y)\n    }\n    function copy_memory_to_memory(src, dst, length)\n    {\n        let i := 0\n        for { } lt(i, length) { i := add(i, 32) }\n        {\n            mstore(add(dst, i), mload(add(src, i)))\n        }\n        if gt(i, length) { mstore(add(dst, length), 0) }\n    }\n    function decrement_t_uint256(value) -> ret\n    {\n        if iszero(value) { panic_error_0x11() }\n        ret := add(value, not(0))\n    }\n    function panic_error_0x11()\n    {\n        mstore(0, shl(224, 0x4e487b71))\n        mstore(4, 0x11)\n        revert(0, 0x24)\n    }\n}",
       "id": 34,
       "language": "Yul",
       "name": "#utility.yul"
     }
   ],
-  "sourceMap": "537:1152:8:-:0;;;828:77;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;872:11;:26;;-1:-1:-1;;;;;;872:26:8;-1:-1:-1;;;;;872:26:8;;;;;;;;;;537:1152;;14:310:34;84:6;137:2;125:9;116:7;112:23;108:32;105:2;;;158:6;150;143:22;105:2;189:16;;-1:-1:-1;;;;;234:31:34;;224:42;;214:2;;285:6;277;270:22;214:2;313:5;95:229;-1:-1:-1;;;95:229:34:o;:::-;537:1152:8;;;;;;",
-  "deployedSourceMap": "537:1152:8:-:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;4073:214:11;;;;;;:::i;:::-;;:::i;:::-;;;2595:14:34;;2588:22;2570:41;;2558:2;2543:18;4073:214:11;;;;;;;;5348:121;;;;;;:::i;:::-;;:::i;:::-;;;2768:25:34;;;2756:2;2741:18;5348:121:11;2723:76:34;5719:145:11;;;;;;:::i;:::-;;:::i;:::-;;6736:214;;;;;;:::i;:::-;;:::i;355:143:17:-;;;;;;:::i;:::-;;:::i;4374:137:11:-;;;;;;:::i;:::-;;:::i;274:74:17:-;;-1:-1:-1;;;;;;;;;;;274:74:17;;2394:49:11;;2439:4;2394:49;;1535:152:8;;;;;;:::i;:::-;;:::i;6098:147:11:-;;;;;;:::i;:::-;;:::i;743:26:8:-;;;;;-1:-1:-1;;;;;743:26:8;;;;;;-1:-1:-1;;;;;2386:32:34;;;2368:51;;2356:2;2341:18;743:26:8;2323:102:34;4073:214:11;4158:4;-1:-1:-1;;;;;;4181:47:11;;-1:-1:-1;;;4181:47:11;;:99;;-1:-1:-1;;;;;;;;;;871:40:32;;;4244:36:11;4174:106;4073:214;-1:-1:-1;;4073:214:11:o;5348:121::-;5414:7;5440:12;;;;;;;;;;:22;;;;5348:121::o;5719:145::-;5802:18;5815:4;5802:12;:18::i;:::-;3958:30;3969:4;3975:12;:10;:12::i;:::-;3958:10;:30::i;:::-;5832:25:::1;5843:4;5849:7;5832:10;:25::i;:::-;5719:145:::0;;;:::o;6736:214::-;6842:12;:10;:12::i;:::-;-1:-1:-1;;;;;6831:23:11;:7;-1:-1:-1;;;;;6831:23:11;;6823:83;;;;-1:-1:-1;;;6823:83:11;;3755:2:34;6823:83:11;;;3737:21:34;3794:2;3774:18;;;3767:30;3833:34;3813:18;;;3806:62;-1:-1:-1;;;3884:18:34;;;3877:45;3939:19;;6823:83:11;;;;;;;;;6917:26;6929:4;6935:7;6917:11;:26::i;:::-;6736:214;;:::o;355:143:17:-;431:4;454:37;-1:-1:-1;;;;;;;;;;;481:9:17;4374:137:11;4452:4;4475:12;;;;;;;;;;;-1:-1:-1;;;;;4475:29:11;;;;;;;;;;;;;;;4374:137::o;1535:152:8:-;1605:14;1622:12;:10;:12::i;:::-;1605:29;;1669:5;1661:6;-1:-1:-1;;;;;1649:31:8;;1676:3;1649:31;;;;2768:25:34;;2756:2;2741:18;;2723:76;1649:31:8;;;;;;;;1535:152;;;:::o;6098:147:11:-;6182:18;6195:4;6182:12;:18::i;:::-;3958:30;3969:4;3975:12;:10;:12::i;3958:30::-;6212:26:::1;6224:4;6230:7;6212:11;:26::i;504:371:17:-:0;566:14;596:30;615:10;596:18;:30::i;:::-;592:277;;;-1:-1:-1;;;781:14:17;777:23;764:37;760:2;756:46;504:371;:::o;745:58::-;-1:-1:-1;665:10:28;;504:371:17:o;4792:375:11:-;4871:22;4879:4;4885:7;4871;:22::i;:::-;4867:294;;5000:41;5028:7;-1:-1:-1;;;;;5000:41:11;5038:2;5000:19;:41::i;:::-;5096:38;5124:4;5131:2;5096:19;:38::i;:::-;4923:225;;;;;;;;;:::i;:::-;;;;-1:-1:-1;;4923:225:11;;;;;;;;;;-1:-1:-1;;;4909:241:11;;;;;;;:::i;7948:224::-;8022:22;8030:4;8036:7;8022;:22::i;:::-;8017:149;;8060:6;:12;;;;;;;;;;;-1:-1:-1;;;;;8060:29:11;;;;;;;;;:36;;-1:-1:-1;;8060:36:11;8092:4;8060:36;;;8142:12;:10;:12::i;:::-;-1:-1:-1;;;;;8115:40:11;8133:7;-1:-1:-1;;;;;8115:40:11;8127:4;8115:40;;;;;;;;;;7948:224;;:::o;8178:225::-;8252:22;8260:4;8266:7;8252;:22::i;:::-;8248:149;;;8322:5;8290:12;;;;;;;;;;;-1:-1:-1;;;;;8290:29:11;;;;;;;;;:37;;-1:-1:-1;;8290:37:11;;;8373:12;:10;:12::i;:::-;-1:-1:-1;;;;;8346:40:11;8364:7;-1:-1:-1;;;;;8346:40:11;8358:4;8346:40;;;;;;;;;;8178:225;;:::o;1531:437:29:-;1606:13;1631:19;1663:10;1667:6;1663:1;:10;:::i;:::-;:14;;1676:1;1663:14;:::i;:::-;-1:-1:-1;;;;;1653:25:29;;;;;-1:-1:-1;;;1653:25:29;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;1653:25:29;;1631:47;;-1:-1:-1;;;1688:6:29;1695:1;1688:9;;;;;;-1:-1:-1;;;1688:9:29;;;;;;;;;;;;:15;-1:-1:-1;;;;;1688:15:29;;;;;;;;;-1:-1:-1;;;1713:6:29;1720:1;1713:9;;;;;;-1:-1:-1;;;1713:9:29;;;;;;;;;;;;:15;-1:-1:-1;;;;;1713:15:29;;;;;;;;-1:-1:-1;1743:9:29;1755:10;1759:6;1755:1;:10;:::i;:::-;:14;;1768:1;1755:14;:::i;:::-;1743:26;;1738:128;1775:1;1771;:5;1738:128;;;-1:-1:-1;;;1818:5:29;1826:3;1818:11;1809:21;;;;;-1:-1:-1;;;1809:21:29;;;;;;;;;;;;1797:6;1804:1;1797:9;;;;;;-1:-1:-1;;;1797:9:29;;;;;;;;;;;;:33;-1:-1:-1;;;;;1797:33:29;;;;;;;;-1:-1:-1;1854:1:29;1844:11;;;;;1778:3;;;:::i;:::-;;;1738:128;;;-1:-1:-1;1883:10:29;;1875:55;;;;-1:-1:-1;;;1875:55:29;;3394:2:34;1875:55:29;;;3376:21:34;;;3413:18;;;3406:30;3472:34;3452:18;;;3445:62;3524:18;;1875:55:29;3366:182:34;1875:55:29;1954:6;1531:437;-1:-1:-1;;;1531:437:29:o;14:173:34:-;82:20;;-1:-1:-1;;;;;131:31:34;;121:42;;111:2;;177:1;174;167:12;111:2;63:124;;;:::o;192:196::-;251:6;304:2;292:9;283:7;279:23;275:32;272:2;;;325:6;317;310:22;272:2;353:29;372:9;353:29;:::i;393:190::-;452:6;505:2;493:9;484:7;480:23;476:32;473:2;;;526:6;518;511:22;473:2;-1:-1:-1;554:23:34;;463:120;-1:-1:-1;463:120:34:o;588:264::-;656:6;664;717:2;705:9;696:7;692:23;688:32;685:2;;;738:6;730;723:22;685:2;779:9;766:23;756:33;;808:38;842:2;831:9;827:18;808:38;:::i;:::-;798:48;;675:177;;;;;:::o;857:306::-;915:6;968:2;956:9;947:7;943:23;939:32;936:2;;;989:6;981;974:22;936:2;1020:23;;-1:-1:-1;;;;;;1072:32:34;;1062:43;;1052:2;;1124:6;1116;1109:22;1168:258;1236:6;1244;1297:2;1285:9;1276:7;1272:23;1268:32;1265:2;;;1318:6;1310;1303:22;1265:2;-1:-1:-1;;1346:23:34;;;1416:2;1401:18;;;1388:32;;-1:-1:-1;1255:171:34:o;1431:786::-;-1:-1:-1;;;1837:3:34;1830:38;1812:3;1897:6;1891:13;1913:62;1968:6;1963:2;1958:3;1954:12;1947:4;1939:6;1935:17;1913:62;:::i;:::-;-1:-1:-1;;;2034:2:34;1994:16;;;2026:11;;;2019:40;2084:13;;2106:63;2084:13;2155:2;2147:11;;2140:4;2128:17;;2106:63;:::i;:::-;2189:17;2208:2;2185:26;;1820:397;-1:-1:-1;;;;1820:397:34:o;2804:383::-;2953:2;2942:9;2935:21;2916:4;2985:6;2979:13;3028:6;3023:2;3012:9;3008:18;3001:34;3044:66;3103:6;3098:2;3087:9;3083:18;3078:2;3070:6;3066:15;3044:66;:::i;:::-;3171:2;3150:15;-1:-1:-1;;3146:29:34;3131:45;;;;3178:2;3127:54;;2925:262;-1:-1:-1;;2925:262:34:o;3969:128::-;4009:3;4040:1;4036:6;4033:1;4030:13;4027:2;;;4046:18;;:::i;:::-;-1:-1:-1;4082:9:34;;4017:80::o;4102:168::-;4142:7;4208:1;4204;4200:6;4196:14;4193:1;4190:21;4185:1;4178:9;4171:17;4167:45;4164:2;;;4215:18;;:::i;:::-;-1:-1:-1;4255:9:34;;4154:116::o;4275:258::-;4347:1;4357:113;4371:6;4368:1;4365:13;4357:113;;;4447:11;;;4441:18;4428:11;;;4421:39;4393:2;4386:10;4357:113;;;4488:6;4485:1;4482:13;4479:2;;;4523:1;4514:6;4509:3;4505:16;4498:27;4479:2;;4328:205;;;:::o;4538:136::-;4577:3;4605:5;4595:2;;4614:18;;:::i;:::-;-1:-1:-1;;;4650:18:34;;4585:89::o;4679:127::-;4740:10;4735:3;4731:20;4728:1;4721:31;4771:4;4768:1;4761:15;4795:4;4792:1;4785:15",
-  "source": "pragma solidity ^0.8.0;\n\nimport \"./freeportParts/MetaTxContext.sol\";\n\n/** The contract NFTAttachment allows users to attach objects to NFTs.\n * Some application can listen for the events and interpret the objects in some way.\n *\n * Anyone can attach objects to any NFT. It is the responsibility of the app to\n * interpret who the sender is and what the object means.\n *\n * An object is identified by CID, a.k.a. Content Identifier or IPFS file, of maximum 32 bytes.\n * The content may be retrieved from Cere DDC or some other store.\n */\ncontract NFTAttachment is /* AccessControl, */ MetaTxContext {\n\n    /** This attachment contract refers to the NFT contract in this variable.\n     * This is informative, there is no validation.\n     */\n    address public nftContract;\n\n    /** Set which NFT contract to refer to.\n     */\n    constructor(address _nftContract) {\n        nftContract = _nftContract;\n    }\n\n    /** The account `sender` wished to attach an object identified by `cid` to the NFT type `nftId`.\n     *\n     * There is absolutely no validation. It is the responsibility of the reader of this event to decide\n     * who the sender is and what the object means.\n     */\n    event AttachToNFT(\n        address indexed sender,\n        uint256 indexed nftId,\n        bytes32 cid);\n\n    /** Attach an object identified by `cid` to the NFT type `nftId`.\n     *\n     * There is absolutely no validation. It is the responsibility of the reader of this event to decide\n     * who the sender is and what the object means.\n     */\n    function attachToNFT(uint256 nftId, bytes32 cid)\n    public {\n        address sender = _msgSender();\n        emit AttachToNFT(sender, nftId, cid);\n    }\n}\n",
+  "sourceMap": "626:3569:8:-:0;;;1178:120;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;-1:-1:-1;;;;;1228:32:8;;1220:41;;;;;;1271:8;:20;;-1:-1:-1;;;;;;1271:20:8;-1:-1:-1;;;;;1271:20:8;;;;;;;;;;626:3569;;14:326:34;100:6;153:2;141:9;132:7;128:23;124:32;121:2;;;174:6;166;159:22;121:2;205:16;;-1:-1:-1;;;;;250:31:34;;240:42;;230:2;;301:6;293;286:22;230:2;329:5;111:229;-1:-1:-1;;;111:229:34:o;:::-;626:3569:8;;;;;;",
+  "deployedSourceMap": "626:3569:8:-:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;4073:214:11;;;;;;:::i;:::-;;:::i;:::-;;;3719:14:34;;3712:22;3694:41;;3682:2;3667:18;4073:214:11;;;;;;;;5348:121;;;;;;:::i;:::-;;:::i;:::-;;;3892:25:34;;;3880:2;3865:18;5348:121:11;3847:76:34;5719:145:11;;;;;;:::i;:::-;;:::i;:::-;;6736:214;;;;;;:::i;:::-;;:::i;355:143:17:-;;;;;;:::i;:::-;;:::i;4374:137:11:-;;;;;;:::i;:::-;;:::i;780:24:8:-;;;;;-1:-1:-1;;;;;780:24:8;;;;;;-1:-1:-1;;;;;3231:32:34;;;3213:51;;3201:2;3186:18;780:24:8;3168:102:34;274:74:17;;-1:-1:-1;;;;;;;;;;;274:74:17;;2394:49:11;;2439:4;2394:49;;2493:360:8;;;;;;:::i;:::-;;:::i;3041:356::-;;;;;;:::i;:::-;;:::i;3961:232::-;;;;;;:::i;:::-;4153:7;4075:86;;3961:232;6098:147:11;;;;;;:::i;:::-;;:::i;3485:248:8:-;;;;;;:::i;:::-;;:::i;4073:214:11:-;4158:4;-1:-1:-1;;;;;;4181:47:11;;-1:-1:-1;;;4181:47:11;;:99;;-1:-1:-1;;;;;;;;;;871:40:32;;;4244:36:11;4174:106;4073:214;-1:-1:-1;;4073:214:11:o;5348:121::-;5414:7;5440:12;;;;;;;;;;:22;;;;5348:121::o;5719:145::-;5802:18;5815:4;5802:12;:18::i;:::-;3958:30;3969:4;3975:12;:10;:12::i;:::-;3958:10;:30::i;:::-;5832:25:::1;5843:4;5849:7;5832:10;:25::i;:::-;5719:145:::0;;;:::o;6736:214::-;6842:12;:10;:12::i;:::-;-1:-1:-1;;;;;6831:23:11;:7;-1:-1:-1;;;;;6831:23:11;;6823:83;;;;-1:-1:-1;;;6823:83:11;;6538:2:34;6823:83:11;;;6520:21:34;6577:2;6557:18;;;6550:30;6616:34;6596:18;;;6589:62;-1:-1:-1;;;6667:18:34;;;6660:45;6722:19;;6823:83:11;;;;;;;;;6917:26;6929:4;6935:7;6917:11;:26::i;:::-;6736:214;;:::o;355:143:17:-;431:4;454:37;-1:-1:-1;;;;;;;;;;;481:9:17;4374:137:11;4452:4;4475:12;;;;;;;;;;;-1:-1:-1;;;;;4475:29:11;;;;;;;;;;;;;;;4374:137::o;2493:360:8:-;2591:17;2583:53;;;;-1:-1:-1;;;2583:53:8;;;;;;;:::i;:::-;2646:14;2663:12;:10;:12::i;:::-;2646:29;;2685:20;2708:23;2725:5;4153:7;4075:86;;3961:232;2708:23;2685:46;;2759:12;-1:-1:-1;;;;;2749:22:8;:6;-1:-1:-1;;;;;2749:22:8;;2741:46;;;;-1:-1:-1;;;2741:46:8;;5846:2:34;2741:46:8;;;5828:21:34;5885:2;5865:18;;;5858:30;-1:-1:-1;;;5904:18:34;;;5897:41;5955:18;;2741:46:8;5818:161:34;2741:46:8;2828:5;2820:6;-1:-1:-1;;;;;2802:44:8;;2835:10;;2802:44;;;;;;;:::i;:::-;;;;;;;;2493:360;;;;;:::o;3041:356::-;3138:17;3130:53;;;;-1:-1:-1;;;3130:53:8;;;;;;;:::i;:::-;3193:13;3209:12;:10;:12::i;:::-;3249:8;;:32;;-1:-1:-1;;;3249:32:8;;-1:-1:-1;;;;;3467:32:34;;;3249::8;;;3449:51:34;3516:18;;;3509:34;;;3193:28:8;;-1:-1:-1;3231:15:8;;3249:8;;;;:18;;3422::34;;3249:32:8;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;3231:50;;3309:1;3299:7;:11;3291:42;;;;-1:-1:-1;;;3291:42:8;;5499:2:34;3291:42:8;;;5481:21:34;5538:2;5518:18;;;5511:30;-1:-1:-1;;;5557:18:34;;;5550:48;5615:18;;3291:42:8;5471:168:34;3291:42:8;3372:5;3365;-1:-1:-1;;;;;3348:42:8;;3379:10;;3348:42;;;;;;;:::i;6098:147:11:-;6182:18;6195:4;6182:12;:18::i;:::-;3958:30;3969:4;3975:12;:10;:12::i;3958:30::-;6212:26:::1;6224:4;6230:7;6212:11;:26::i;3485:248:8:-:0;3583:17;3575:53;;;;-1:-1:-1;;;3575:53:8;;;;;;;:::i;:::-;3638:14;3655:12;:10;:12::i;:::-;3638:29;;3708:5;3700:6;-1:-1:-1;;;;;3682:44:8;;3715:10;;3682:44;;;;;;;:::i;:::-;;;;;;;;3485:248;;;;:::o;504:371:17:-;566:14;596:30;615:10;596:18;:30::i;:::-;592:277;;;-1:-1:-1;;;781:14:17;777:23;764:37;760:2;756:46;504:371;:::o;745:58::-;-1:-1:-1;665:10:28;;504:371:17:o;4792:375:11:-;4871:22;4879:4;4885:7;4871;:22::i;:::-;4867:294;;5000:41;5028:7;-1:-1:-1;;;;;5000:41:11;5038:2;5000:19;:41::i;:::-;5096:38;5124:4;5131:2;5096:19;:38::i;:::-;4923:225;;;;;;;;;:::i;:::-;;;;-1:-1:-1;;4923:225:11;;;;;;;;;;-1:-1:-1;;;4909:241:11;;;;;;;:::i;7948:224::-;8022:22;8030:4;8036:7;8022;:22::i;:::-;8017:149;;8060:6;:12;;;;;;;;;;;-1:-1:-1;;;;;8060:29:11;;;;;;;;;:36;;-1:-1:-1;;8060:36:11;8092:4;8060:36;;;8142:12;:10;:12::i;:::-;-1:-1:-1;;;;;8115:40:11;8133:7;-1:-1:-1;;;;;8115:40:11;8127:4;8115:40;;;;;;;;;;7948:224;;:::o;8178:225::-;8252:22;8260:4;8266:7;8252;:22::i;:::-;8248:149;;;8322:5;8290:12;;;;;;;;;;;-1:-1:-1;;;;;8290:29:11;;;;;;;;;:37;;-1:-1:-1;;8290:37:11;;;8373:12;:10;:12::i;:::-;-1:-1:-1;;;;;8346:40:11;8364:7;-1:-1:-1;;;;;8346:40:11;8358:4;8346:40;;;;;;;;;;8178:225;;:::o;1531:437:29:-;1606:13;1631:19;1663:10;1667:6;1663:1;:10;:::i;:::-;:14;;1676:1;1663:14;:::i;:::-;-1:-1:-1;;;;;1653:25:29;;;;;-1:-1:-1;;;1653:25:29;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;1653:25:29;;1631:47;;-1:-1:-1;;;1688:6:29;1695:1;1688:9;;;;;;-1:-1:-1;;;1688:9:29;;;;;;;;;;;;:15;-1:-1:-1;;;;;1688:15:29;;;;;;;;;-1:-1:-1;;;1713:6:29;1720:1;1713:9;;;;;;-1:-1:-1;;;1713:9:29;;;;;;;;;;;;:15;-1:-1:-1;;;;;1713:15:29;;;;;;;;-1:-1:-1;1743:9:29;1755:10;1759:6;1755:1;:10;:::i;:::-;:14;;1768:1;1755:14;:::i;:::-;1743:26;;1738:128;1775:1;1771;:5;1738:128;;;-1:-1:-1;;;1818:5:29;1826:3;1818:11;1809:21;;;;;-1:-1:-1;;;1809:21:29;;;;;;;;;;;;1797:6;1804:1;1797:9;;;;;;-1:-1:-1;;;1797:9:29;;;;;;;;;;;;:33;-1:-1:-1;;;;;1797:33:29;;;;;;;;-1:-1:-1;1854:1:29;1844:11;;;;;1778:3;;;:::i;:::-;;;1738:128;;;-1:-1:-1;1883:10:29;;1875:55;;;;-1:-1:-1;;;1875:55:29;;5138:2:34;1875:55:29;;;5120:21:34;;;5157:18;;;5150:30;5216:34;5196:18;;;5189:62;5268:18;;1875:55:29;5110:182:34;1875:55:29;1954:6;1531:437;-1:-1:-1;;;1531:437:29:o;14:173:34:-;82:20;;-1:-1:-1;;;;;131:31:34;;121:42;;111:2;;177:1;174;167:12;111:2;63:124;;;:::o;192:196::-;251:6;304:2;292:9;283:7;279:23;275:32;272:2;;;325:6;317;310:22;272:2;353:29;372:9;353:29;:::i;393:190::-;452:6;505:2;493:9;484:7;480:23;476:32;473:2;;;526:6;518;511:22;473:2;-1:-1:-1;554:23:34;;463:120;-1:-1:-1;463:120:34:o;588:264::-;656:6;664;717:2;705:9;696:7;692:23;688:32;685:2;;;738:6;730;723:22;685:2;779:9;766:23;756:33;;808:38;842:2;831:9;827:18;808:38;:::i;:::-;798:48;;675:177;;;;;:::o;857:306::-;915:6;968:2;956:9;947:7;943:23;939:32;936:2;;;989:6;981;974:22;936:2;1020:23;;-1:-1:-1;;;;;;1072:32:34;;1062:43;;1052:2;;1124:6;1116;1109:22;1363:194;1433:6;1486:2;1474:9;1465:7;1461:23;1457:32;1454:2;;;1507:6;1499;1492:22;1454:2;-1:-1:-1;1535:16:34;;1444:113;-1:-1:-1;1444:113:34:o;1562:709::-;1641:6;1649;1657;1710:2;1698:9;1689:7;1685:23;1681:32;1678:2;;;1731:6;1723;1716:22;1678:2;1759:23;;;-1:-1:-1;1833:2:34;1818:18;;1805:32;-1:-1:-1;;;;;1886:14:34;;;1883:2;;;1918:6;1910;1903:22;1883:2;1961:6;1950:9;1946:22;1936:32;;2006:7;1999:4;1995:2;1991:13;1987:27;1977:2;;2033:6;2025;2018:22;1977:2;2078;2065:16;2104:2;2096:6;2093:14;2090:2;;;2125:6;2117;2110:22;2090:2;2175:7;2170:2;2161:6;2157:2;2153:15;2149:24;2146:37;2143:2;;;2201:6;2193;2186:22;2143:2;2237;2233;2229:11;2219:21;;2259:6;2249:16;;;;;1668:603;;;;;:::o;2276:786::-;-1:-1:-1;;;2682:3:34;2675:38;2657:3;2742:6;2736:13;2758:62;2813:6;2808:2;2803:3;2799:12;2792:4;2784:6;2780:17;2758:62;:::i;:::-;-1:-1:-1;;;2879:2:34;2839:16;;;2871:11;;;2864:40;2929:13;;2951:63;2929:13;3000:2;2992:11;;2985:4;2973:17;;2951:63;:::i;:::-;3034:17;3053:2;3030:26;;2665:397;-1:-1:-1;;;;2665:397:34:o;3928:391::-;4085:2;4074:9;4067:21;4124:6;4119:2;4108:9;4104:18;4097:34;4181:6;4173;4168:2;4157:9;4153:18;4140:48;4048:4;4208:22;;;4232:2;4204:31;;;4197:45;;;;4303:2;4282:15;;;-1:-1:-1;;4278:29:34;4263:45;4259:54;;4057:262;-1:-1:-1;4057:262:34:o;4548:383::-;4697:2;4686:9;4679:21;4660:4;4729:6;4723:13;4772:6;4767:2;4756:9;4752:18;4745:34;4788:66;4847:6;4842:2;4831:9;4827:18;4822:2;4814:6;4810:15;4788:66;:::i;:::-;4915:2;4894:15;-1:-1:-1;;4890:29:34;4875:45;;;;4922:2;4871:54;;4669:262;-1:-1:-1;;4669:262:34:o;5984:347::-;6186:2;6168:21;;;6225:2;6205:18;;;6198:30;-1:-1:-1;;;6259:2:34;6244:18;;6237:53;6322:2;6307:18;;6158:173::o;6752:128::-;6792:3;6823:1;6819:6;6816:1;6813:13;6810:2;;;6829:18;;:::i;:::-;-1:-1:-1;6865:9:34;;6800:80::o;6885:168::-;6925:7;6991:1;6987;6983:6;6979:14;6976:1;6973:21;6968:1;6961:9;6954:17;6950:45;6947:2;;;6998:18;;:::i;:::-;-1:-1:-1;7038:9:34;;6937:116::o;7058:258::-;7130:1;7140:113;7154:6;7151:1;7148:13;7140:113;;;7230:11;;;7224:18;7211:11;;;7204:39;7176:2;7169:10;7140:113;;;7271:6;7268:1;7265:13;7262:2;;;7306:1;7297:6;7292:3;7288:16;7281:27;7262:2;;7111:205;;;:::o;7321:136::-;7360:3;7388:5;7378:2;;7397:18;;:::i;:::-;-1:-1:-1;;;7433:18:34;;7368:89::o;7462:127::-;7523:10;7518:3;7514:20;7511:1;7504:31;7554:4;7551:1;7544:15;7578:4;7575:1;7568:15",
+  "source": "pragma solidity ^0.8.0;\n\nimport \"./freeportParts/MetaTxContext.sol\";\nimport \"./Freeport.sol\";\n\n/** The contract NFTAttachment allows users to attach objects to NFTs.\n * Some application can listen for the events and interpret the objects in some way.\n *\n * There are three roles who can attach objects to an NFT:\n * the minter, any current owner, or any anonymous account.\n * A different event is emitted for each role.\n *\n * The attachment data is meant to identify an object hosted externally,\n * such as a CID, a.k.a. Content Identifier, or a DDC URL.\n * The content may be retrieved from Cere DDC or some other store.\n */\ncontract NFTAttachment is /* AccessControl, */ MetaTxContext {\n\n    /** This attachment contract refers to the NFT contract in this variable.\n     */\n    Freeport public freeport;\n\n    /** The token ID that represents the internal currency for all payments in Freeport. */\n    uint256 constant CURRENCY = 0;\n\n    /** Set which NFT contract to refer to.\n     *\n     * The event `MinterAttachToNFT` is only supported for Freeport-compatible NFTs.\n     *\n     * The event `OwnerAttachToNFT` is supported for ERC-1155 NFTs, including Freeport.\n     */\n    constructor(Freeport _freeport) {\n        require(address(_freeport) != address(0));\n        freeport = _freeport;\n    }\n\n    /** The account `minter` wished to attach data `attachment` to the NFT type `nftId`.\n     *\n     * The `minter` is the minter who created this NFT type, or may create it in the future if it does not exist.\n     */\n    event MinterAttachToNFT(\n        address indexed minter,\n        uint256 indexed nftId,\n        bytes attachment);\n\n    /** The account `owner` wished to attach data `attachment` to the NFT type `nftId`.\n     *\n     * The `owner` owned at least one NFT of this type at the time of the event.\n     */\n    event OwnerAttachToNFT(\n        address indexed owner,\n        uint256 indexed nftId,\n        bytes attachment);\n\n    /** The account `anonym` wished to attach data `attachment` to the NFT type `nftId`.\n     *\n     * There is absolutely no validation. It is the responsibility of the reader of this event to decide\n     * who the sender is and what the attachment means.\n     */\n    event AnonymAttachToNFT(\n        address indexed anonym,\n        uint256 indexed nftId,\n        bytes attachment);\n\n    /** Attach data `attachment` to the NFT type `nftId`, as the minter of this NFT type.\n     *\n     * This only works for NFT IDs in the Freeport format.\n     */\n    function minterAttachToNFT(uint256 nftId, bytes calldata attachment)\n    public {\n        require(nftId != CURRENCY, \"0 is not a valid NFT ID\");\n        address minter = _msgSender();\n        address actualMinter = _minterFromNftId(nftId);\n        require(minter == actualMinter, \"Only minter\");\n        emit MinterAttachToNFT(minter, nftId, attachment);\n    }\n\n    /** Attach data `attachment` to the NFT type `nftId`, as a current owner of an NFT of this type.\n     *\n     * This works for NFTs in the ERC-1155 or Freeport standards.\n     */\n    function ownerAttachToNFT(uint256 nftId, bytes calldata attachment)\n    public {\n        require(nftId != CURRENCY, \"0 is not a valid NFT ID\");\n        address owner = _msgSender();\n        uint256 balance = freeport.balanceOf(owner, nftId);\n        require(balance > 0, \"Only current owner\");\n        emit OwnerAttachToNFT(owner, nftId, attachment);\n    }\n\n    /** Attach data `attachment` to the NFT type `nftId`, as any account.\n     */\n    function anonymAttachToNFT(uint256 nftId, bytes calldata attachment)\n    public {\n        require(nftId != CURRENCY, \"0 is not a valid NFT ID\");\n        address anonym = _msgSender();\n        emit AnonymAttachToNFT(anonym, nftId, attachment);\n    }\n\n    /** Parse an NFT ID into its issuer, its supply, and an arbitrary nonce.\n     *\n     * This does not imply that the NFTs exist.\n     *\n     * This is specific to Freeport NFTs. See `freeportParts/Issuance.sol`\n     */\n    function _minterFromNftId(uint256 id)\n    public pure returns (address minter) {\n        minter = address(uint160((id & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000000000000000) >> (32 + 64)));\n        return minter;\n    }\n}\n",
   "sourcePath": "/home/a/CERE/Freeport-Smart-Contracts/contracts/NFTAttachment.sol",
   "ast": {
     "absolutePath": "project:/contracts/NFTAttachment.sol",
     "exportedSymbols": {
       "AccessControl": [
-        2024
+        2208
+      ],
+      "Address": [
+        5579
+      ],
+      "BaseNFT": [
+        2338
       ],
       "Context": [
-        5418
+        5602
+      ],
+      "Currency": [
+        2405
+      ],
+      "ERC1155": [
+        5020
       ],
       "ERC165": [
-        5927
+        6111
+      ],
+      "ERC20Adapter": [
+        2503
+      ],
+      "Freeport": [
+        947
       ],
       "IAccessControl": [
-        1700
+        1884
+      ],
+      "IERC1155": [
+        5142
+      ],
+      "IERC1155MetadataURI": [
+        5198
+      ],
+      "IERC1155Receiver": [
+        5183
       ],
       "IERC165": [
-        5939
+        6123
+      ],
+      "IERC20": [
+        584
+      ],
+      "Issuance": [
+        2757
+      ],
+      "JointAccounts": [
+        3094
       ],
       "MetaTxContext": [
-        2980
+        3164
       ],
       "NFTAttachment": [
-        1167
+        1322
+      ],
+      "SimpleExchange": [
+        3341
       ],
       "Strings": [
-        5621
+        5805
+      ],
+      "TransferFees": [
+        3950
+      ],
+      "TransferOperator": [
+        3987
       ]
     },
-    "id": 1168,
+    "id": 1323,
     "nodeType": "SourceUnit",
     "nodes": [
       {
@@ -3972,9 +6039,21 @@
         "id": 1120,
         "nameLocation": "-1:-1:-1",
         "nodeType": "ImportDirective",
-        "scope": 1168,
-        "sourceUnit": 2981,
+        "scope": 1323,
+        "sourceUnit": 3165,
         "src": "25:43:8",
+        "symbolAliases": [],
+        "unitAlias": ""
+      },
+      {
+        "absolutePath": "project:/contracts/Freeport.sol",
+        "file": "./Freeport.sol",
+        "id": 1121,
+        "nameLocation": "-1:-1:-1",
+        "nodeType": "ImportDirective",
+        "scope": 1323,
+        "sourceUnit": 948,
+        "src": "69:24:8",
         "symbolAliases": [],
         "unitAlias": ""
       },
@@ -3983,133 +6062,366 @@
         "baseContracts": [
           {
             "baseName": {
-              "id": 1122,
+              "id": 1123,
               "name": "MetaTxContext",
               "nodeType": "IdentifierPath",
-              "referencedDeclaration": 2980,
-              "src": "584:13:8"
+              "referencedDeclaration": 3164,
+              "src": "673:13:8"
             },
-            "id": 1123,
+            "id": 1124,
             "nodeType": "InheritanceSpecifier",
-            "src": "584:13:8"
+            "src": "673:13:8"
           }
         ],
         "contractDependencies": [],
         "contractKind": "contract",
         "documentation": {
-          "id": 1121,
+          "id": 1122,
           "nodeType": "StructuredDocumentation",
-          "src": "70:466:8",
-          "text": "The contract NFTAttachment allows users to attach objects to NFTs.\n Some application can listen for the events and interpret the objects in some way.\n Anyone can attach objects to any NFT. It is the responsibility of the app to\n interpret who the sender is and what the object means.\n An object is identified by CID, a.k.a. Content Identifier or IPFS file, of maximum 32 bytes.\n The content may be retrieved from Cere DDC or some other store."
+          "src": "95:530:8",
+          "text": "The contract NFTAttachment allows users to attach objects to NFTs.\n Some application can listen for the events and interpret the objects in some way.\n There are three roles who can attach objects to an NFT:\n the minter, any current owner, or any anonymous account.\n A different event is emitted for each role.\n The attachment data is meant to identify an object hosted externally,\n such as a CID, a.k.a. Content Identifier, or a DDC URL.\n The content may be retrieved from Cere DDC or some other store."
         },
         "fullyImplemented": true,
-        "id": 1167,
+        "id": 1322,
         "linearizedBaseContracts": [
-          1167,
-          2980,
-          2024,
-          5927,
-          5939,
-          1700,
-          5418
+          1322,
+          3164,
+          2208,
+          6111,
+          6123,
+          1884,
+          5602
         ],
         "name": "NFTAttachment",
-        "nameLocation": "546:13:8",
+        "nameLocation": "635:13:8",
         "nodeType": "ContractDefinition",
         "nodes": [
           {
             "constant": false,
             "documentation": {
-              "id": 1124,
+              "id": 1125,
               "nodeType": "StructuredDocumentation",
-              "src": "605:133:8",
-              "text": "This attachment contract refers to the NFT contract in this variable.\n This is informative, there is no validation."
+              "src": "694:81:8",
+              "text": "This attachment contract refers to the NFT contract in this variable."
             },
-            "functionSelector": "d56d229d",
-            "id": 1126,
+            "functionSelector": "9470ad85",
+            "id": 1128,
             "mutability": "mutable",
-            "name": "nftContract",
-            "nameLocation": "758:11:8",
+            "name": "freeport",
+            "nameLocation": "796:8:8",
             "nodeType": "VariableDeclaration",
-            "scope": 1167,
-            "src": "743:26:8",
+            "scope": 1322,
+            "src": "780:24:8",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
-              "typeIdentifier": "t_address",
-              "typeString": "address"
+              "typeIdentifier": "t_contract$_Freeport_$947",
+              "typeString": "contract Freeport"
             },
             "typeName": {
-              "id": 1125,
-              "name": "address",
-              "nodeType": "ElementaryTypeName",
-              "src": "743:7:8",
-              "stateMutability": "nonpayable",
+              "id": 1127,
+              "nodeType": "UserDefinedTypeName",
+              "pathNode": {
+                "id": 1126,
+                "name": "Freeport",
+                "nodeType": "IdentifierPath",
+                "referencedDeclaration": 947,
+                "src": "780:8:8"
+              },
+              "referencedDeclaration": 947,
+              "src": "780:8:8",
               "typeDescriptions": {
-                "typeIdentifier": "t_address",
-                "typeString": "address"
+                "typeIdentifier": "t_contract$_Freeport_$947",
+                "typeString": "contract Freeport"
               }
             },
             "visibility": "public"
           },
           {
+            "constant": true,
+            "documentation": {
+              "id": 1129,
+              "nodeType": "StructuredDocumentation",
+              "src": "811:87:8",
+              "text": "The token ID that represents the internal currency for all payments in Freeport. "
+            },
+            "id": 1132,
+            "mutability": "constant",
+            "name": "CURRENCY",
+            "nameLocation": "920:8:8",
+            "nodeType": "VariableDeclaration",
+            "scope": 1322,
+            "src": "903:29:8",
+            "stateVariable": true,
+            "storageLocation": "default",
+            "typeDescriptions": {
+              "typeIdentifier": "t_uint256",
+              "typeString": "uint256"
+            },
+            "typeName": {
+              "id": 1130,
+              "name": "uint256",
+              "nodeType": "ElementaryTypeName",
+              "src": "903:7:8",
+              "typeDescriptions": {
+                "typeIdentifier": "t_uint256",
+                "typeString": "uint256"
+              }
+            },
+            "value": {
+              "hexValue": "30",
+              "id": 1131,
+              "isConstant": false,
+              "isLValue": false,
+              "isPure": true,
+              "kind": "number",
+              "lValueRequested": false,
+              "nodeType": "Literal",
+              "src": "931:1:8",
+              "typeDescriptions": {
+                "typeIdentifier": "t_rational_0_by_1",
+                "typeString": "int_const 0"
+              },
+              "value": "0"
+            },
+            "visibility": "internal"
+          },
+          {
             "body": {
-              "id": 1136,
+              "id": 1155,
               "nodeType": "Block",
-              "src": "862:43:8",
+              "src": "1210:88:8",
               "statements": [
                 {
                   "expression": {
-                    "id": 1134,
+                    "arguments": [
+                      {
+                        "commonType": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        },
+                        "id": 1148,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "arguments": [
+                            {
+                              "id": 1142,
+                              "name": "_freeport",
+                              "nodeType": "Identifier",
+                              "overloadedDeclarations": [],
+                              "referencedDeclaration": 1136,
+                              "src": "1236:9:8",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_contract$_Freeport_$947",
+                                "typeString": "contract Freeport"
+                              }
+                            }
+                          ],
+                          "expression": {
+                            "argumentTypes": [
+                              {
+                                "typeIdentifier": "t_contract$_Freeport_$947",
+                                "typeString": "contract Freeport"
+                              }
+                            ],
+                            "id": 1141,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "lValueRequested": false,
+                            "nodeType": "ElementaryTypeNameExpression",
+                            "src": "1228:7:8",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_type$_t_address_$",
+                              "typeString": "type(address)"
+                            },
+                            "typeName": {
+                              "id": 1140,
+                              "name": "address",
+                              "nodeType": "ElementaryTypeName",
+                              "src": "1228:7:8",
+                              "typeDescriptions": {}
+                            }
+                          },
+                          "id": 1143,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "kind": "typeConversion",
+                          "lValueRequested": false,
+                          "names": [],
+                          "nodeType": "FunctionCall",
+                          "src": "1228:18:8",
+                          "tryCall": false,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": "!=",
+                        "rightExpression": {
+                          "arguments": [
+                            {
+                              "hexValue": "30",
+                              "id": 1146,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": true,
+                              "kind": "number",
+                              "lValueRequested": false,
+                              "nodeType": "Literal",
+                              "src": "1258:1:8",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_rational_0_by_1",
+                                "typeString": "int_const 0"
+                              },
+                              "value": "0"
+                            }
+                          ],
+                          "expression": {
+                            "argumentTypes": [
+                              {
+                                "typeIdentifier": "t_rational_0_by_1",
+                                "typeString": "int_const 0"
+                              }
+                            ],
+                            "id": 1145,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "lValueRequested": false,
+                            "nodeType": "ElementaryTypeNameExpression",
+                            "src": "1250:7:8",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_type$_t_address_$",
+                              "typeString": "type(address)"
+                            },
+                            "typeName": {
+                              "id": 1144,
+                              "name": "address",
+                              "nodeType": "ElementaryTypeName",
+                              "src": "1250:7:8",
+                              "typeDescriptions": {}
+                            }
+                          },
+                          "id": 1147,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "typeConversion",
+                          "lValueRequested": false,
+                          "names": [],
+                          "nodeType": "FunctionCall",
+                          "src": "1250:10:8",
+                          "tryCall": false,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          }
+                        },
+                        "src": "1228:32:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      ],
+                      "id": 1139,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        4294967278,
+                        4294967278
+                      ],
+                      "referencedDeclaration": 4294967278,
+                      "src": "1220:7:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
+                        "typeString": "function (bool) pure"
+                      }
+                    },
+                    "id": 1149,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "1220:41:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 1150,
+                  "nodeType": "ExpressionStatement",
+                  "src": "1220:41:8"
+                },
+                {
+                  "expression": {
+                    "id": 1153,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
-                      "id": 1132,
-                      "name": "nftContract",
+                      "id": 1151,
+                      "name": "freeport",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 1126,
-                      "src": "872:11:8",
+                      "referencedDeclaration": 1128,
+                      "src": "1271:8:8",
                       "typeDescriptions": {
-                        "typeIdentifier": "t_address",
-                        "typeString": "address"
+                        "typeIdentifier": "t_contract$_Freeport_$947",
+                        "typeString": "contract Freeport"
                       }
                     },
                     "nodeType": "Assignment",
                     "operator": "=",
                     "rightHandSide": {
-                      "id": 1133,
-                      "name": "_nftContract",
+                      "id": 1152,
+                      "name": "_freeport",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 1129,
-                      "src": "886:12:8",
+                      "referencedDeclaration": 1136,
+                      "src": "1282:9:8",
                       "typeDescriptions": {
-                        "typeIdentifier": "t_address",
-                        "typeString": "address"
+                        "typeIdentifier": "t_contract$_Freeport_$947",
+                        "typeString": "contract Freeport"
                       }
                     },
-                    "src": "872:26:8",
+                    "src": "1271:20:8",
                     "typeDescriptions": {
-                      "typeIdentifier": "t_address",
-                      "typeString": "address"
+                      "typeIdentifier": "t_contract$_Freeport_$947",
+                      "typeString": "contract Freeport"
                     }
                   },
-                  "id": 1135,
+                  "id": 1154,
                   "nodeType": "ExpressionStatement",
-                  "src": "872:26:8"
+                  "src": "1271:20:8"
                 }
               ]
             },
             "documentation": {
-              "id": 1127,
+              "id": 1133,
               "nodeType": "StructuredDocumentation",
-              "src": "776:47:8",
-              "text": "Set which NFT contract to refer to."
+              "src": "939:234:8",
+              "text": "Set which NFT contract to refer to.\n The event `MinterAttachToNFT` is only supported for Freeport-compatible NFTs.\n The event `OwnerAttachToNFT` is supported for ERC-1155 NFTs, including Freeport."
             },
-            "id": 1137,
+            "id": 1156,
             "implemented": true,
             "kind": "constructor",
             "modifiers": [],
@@ -4117,48 +6429,54 @@
             "nameLocation": "-1:-1:-1",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1130,
+              "id": 1137,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1129,
+                  "id": 1136,
                   "mutability": "mutable",
-                  "name": "_nftContract",
-                  "nameLocation": "848:12:8",
+                  "name": "_freeport",
+                  "nameLocation": "1199:9:8",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1137,
-                  "src": "840:20:8",
+                  "scope": 1156,
+                  "src": "1190:18:8",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
-                    "typeIdentifier": "t_address",
-                    "typeString": "address"
+                    "typeIdentifier": "t_contract$_Freeport_$947",
+                    "typeString": "contract Freeport"
                   },
                   "typeName": {
-                    "id": 1128,
-                    "name": "address",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "840:7:8",
-                    "stateMutability": "nonpayable",
+                    "id": 1135,
+                    "nodeType": "UserDefinedTypeName",
+                    "pathNode": {
+                      "id": 1134,
+                      "name": "Freeport",
+                      "nodeType": "IdentifierPath",
+                      "referencedDeclaration": 947,
+                      "src": "1190:8:8"
+                    },
+                    "referencedDeclaration": 947,
+                    "src": "1190:8:8",
                     "typeDescriptions": {
-                      "typeIdentifier": "t_address",
-                      "typeString": "address"
+                      "typeIdentifier": "t_contract$_Freeport_$947",
+                      "typeString": "contract Freeport"
                     }
                   },
                   "visibility": "internal"
                 }
               ],
-              "src": "839:22:8"
+              "src": "1189:20:8"
             },
             "returnParameters": {
-              "id": 1131,
+              "id": 1138,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "862:0:8"
+              "src": "1210:0:8"
             },
-            "scope": 1167,
-            "src": "828:77:8",
+            "scope": 1322,
+            "src": "1178:120:8",
             "stateMutability": "nonpayable",
             "virtual": false,
             "visibility": "public"
@@ -4166,29 +6484,29 @@
           {
             "anonymous": false,
             "documentation": {
-              "id": 1138,
+              "id": 1157,
               "nodeType": "StructuredDocumentation",
-              "src": "911:268:8",
-              "text": "The account `sender` wished to attach an object identified by `cid` to the NFT type `nftId`.\n There is absolutely no validation. It is the responsibility of the reader of this event to decide\n who the sender is and what the object means."
+              "src": "1304:213:8",
+              "text": "The account `minter` wished to attach data `attachment` to the NFT type `nftId`.\n The `minter` is the minter who created this NFT type, or may create it in the future if it does not exist."
             },
-            "id": 1146,
-            "name": "AttachToNFT",
-            "nameLocation": "1190:11:8",
+            "id": 1165,
+            "name": "MinterAttachToNFT",
+            "nameLocation": "1528:17:8",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 1145,
+              "id": 1164,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1140,
+                  "id": 1159,
                   "indexed": true,
                   "mutability": "mutable",
-                  "name": "sender",
-                  "nameLocation": "1227:6:8",
+                  "name": "minter",
+                  "nameLocation": "1571:6:8",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1146,
-                  "src": "1211:22:8",
+                  "scope": 1165,
+                  "src": "1555:22:8",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -4196,10 +6514,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1139,
+                    "id": 1158,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1211:7:8",
+                    "src": "1555:7:8",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -4210,14 +6528,14 @@
                 },
                 {
                   "constant": false,
-                  "id": 1142,
+                  "id": 1161,
                   "indexed": true,
                   "mutability": "mutable",
                   "name": "nftId",
-                  "nameLocation": "1259:5:8",
+                  "nameLocation": "1603:5:8",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1146,
-                  "src": "1243:21:8",
+                  "scope": 1165,
+                  "src": "1587:21:8",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -4225,10 +6543,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1141,
+                    "id": 1160,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1243:7:8",
+                    "src": "1587:7:8",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -4238,57 +6556,375 @@
                 },
                 {
                   "constant": false,
-                  "id": 1144,
+                  "id": 1163,
                   "indexed": false,
                   "mutability": "mutable",
-                  "name": "cid",
-                  "nameLocation": "1282:3:8",
+                  "name": "attachment",
+                  "nameLocation": "1624:10:8",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1146,
-                  "src": "1274:11:8",
+                  "scope": 1165,
+                  "src": "1618:16:8",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
-                    "typeIdentifier": "t_bytes32",
-                    "typeString": "bytes32"
+                    "typeIdentifier": "t_bytes_memory_ptr",
+                    "typeString": "bytes"
                   },
                   "typeName": {
-                    "id": 1143,
-                    "name": "bytes32",
+                    "id": 1162,
+                    "name": "bytes",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1274:7:8",
+                    "src": "1618:5:8",
                     "typeDescriptions": {
-                      "typeIdentifier": "t_bytes32",
-                      "typeString": "bytes32"
+                      "typeIdentifier": "t_bytes_storage_ptr",
+                      "typeString": "bytes"
                     }
                   },
                   "visibility": "internal"
                 }
               ],
-              "src": "1201:85:8"
+              "src": "1545:90:8"
             },
-            "src": "1184:103:8"
+            "src": "1522:114:8"
+          },
+          {
+            "anonymous": false,
+            "documentation": {
+              "id": 1166,
+              "nodeType": "StructuredDocumentation",
+              "src": "1642:179:8",
+              "text": "The account `owner` wished to attach data `attachment` to the NFT type `nftId`.\n The `owner` owned at least one NFT of this type at the time of the event."
+            },
+            "id": 1174,
+            "name": "OwnerAttachToNFT",
+            "nameLocation": "1832:16:8",
+            "nodeType": "EventDefinition",
+            "parameters": {
+              "id": 1173,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 1168,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "owner",
+                  "nameLocation": "1874:5:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1174,
+                  "src": "1858:21:8",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 1167,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1858:7:8",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 1170,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "nftId",
+                  "nameLocation": "1905:5:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1174,
+                  "src": "1889:21:8",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 1169,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1889:7:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 1172,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "attachment",
+                  "nameLocation": "1926:10:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1174,
+                  "src": "1920:16:8",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes_memory_ptr",
+                    "typeString": "bytes"
+                  },
+                  "typeName": {
+                    "id": 1171,
+                    "name": "bytes",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1920:5:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes_storage_ptr",
+                      "typeString": "bytes"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "1848:89:8"
+            },
+            "src": "1826:112:8"
+          },
+          {
+            "anonymous": false,
+            "documentation": {
+              "id": 1175,
+              "nodeType": "StructuredDocumentation",
+              "src": "1944:260:8",
+              "text": "The account `anonym` wished to attach data `attachment` to the NFT type `nftId`.\n There is absolutely no validation. It is the responsibility of the reader of this event to decide\n who the sender is and what the attachment means."
+            },
+            "id": 1183,
+            "name": "AnonymAttachToNFT",
+            "nameLocation": "2215:17:8",
+            "nodeType": "EventDefinition",
+            "parameters": {
+              "id": 1182,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 1177,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "anonym",
+                  "nameLocation": "2258:6:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1183,
+                  "src": "2242:22:8",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 1176,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2242:7:8",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 1179,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "nftId",
+                  "nameLocation": "2290:5:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1183,
+                  "src": "2274:21:8",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 1178,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2274:7:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 1181,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "attachment",
+                  "nameLocation": "2311:10:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1183,
+                  "src": "2305:16:8",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes_memory_ptr",
+                    "typeString": "bytes"
+                  },
+                  "typeName": {
+                    "id": 1180,
+                    "name": "bytes",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2305:5:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes_storage_ptr",
+                      "typeString": "bytes"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "2232:90:8"
+            },
+            "src": "2209:114:8"
           },
           {
             "body": {
-              "id": 1165,
+              "id": 1222,
               "nodeType": "Block",
-              "src": "1595:92:8",
+              "src": "2573:280:8",
               "statements": [
                 {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "commonType": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        },
+                        "id": 1194,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "id": 1192,
+                          "name": "nftId",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 1186,
+                          "src": "2591:5:8",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": "!=",
+                        "rightExpression": {
+                          "id": 1193,
+                          "name": "CURRENCY",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 1132,
+                          "src": "2600:8:8",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        "src": "2591:17:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      },
+                      {
+                        "hexValue": "30206973206e6f7420612076616c6964204e4654204944",
+                        "id": 1195,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "string",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "2610:25:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_stringliteral_ae13f91217f47fbcc2b0198f394de1f4adce3e41753550c13e2321d5da6b1b56",
+                          "typeString": "literal_string \"0 is not a valid NFT ID\""
+                        },
+                        "value": "0 is not a valid NFT ID"
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        },
+                        {
+                          "typeIdentifier": "t_stringliteral_ae13f91217f47fbcc2b0198f394de1f4adce3e41753550c13e2321d5da6b1b56",
+                          "typeString": "literal_string \"0 is not a valid NFT ID\""
+                        }
+                      ],
+                      "id": 1191,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        4294967278,
+                        4294967278
+                      ],
+                      "referencedDeclaration": 4294967278,
+                      "src": "2583:7:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
+                        "typeString": "function (bool,string memory) pure"
+                      }
+                    },
+                    "id": 1196,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "2583:53:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 1197,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2583:53:8"
+                },
+                {
                   "assignments": [
-                    1155
+                    1199
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1155,
+                      "id": 1199,
                       "mutability": "mutable",
-                      "name": "sender",
-                      "nameLocation": "1613:6:8",
+                      "name": "minter",
+                      "nameLocation": "2654:6:8",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1165,
-                      "src": "1605:14:8",
+                      "scope": 1222,
+                      "src": "2646:14:8",
                       "stateVariable": false,
                       "storageLocation": "default",
                       "typeDescriptions": {
@@ -4296,10 +6932,10 @@
                         "typeString": "address"
                       },
                       "typeName": {
-                        "id": 1154,
+                        "id": 1198,
                         "name": "address",
                         "nodeType": "ElementaryTypeName",
-                        "src": "1605:7:8",
+                        "src": "2646:7:8",
                         "stateMutability": "nonpayable",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
@@ -4309,25 +6945,25 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1158,
+                  "id": 1202,
                   "initialValue": {
                     "arguments": [],
                     "expression": {
                       "argumentTypes": [],
-                      "id": 1156,
+                      "id": 1200,
                       "name": "_msgSender",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2952
+                        3136
                       ],
-                      "referencedDeclaration": 2952,
-                      "src": "1622:10:8",
+                      "referencedDeclaration": 3136,
+                      "src": "2663:10:8",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_view$__$returns$_t_address_$",
                         "typeString": "function () view returns (address)"
                       }
                     },
-                    "id": 1157,
+                    "id": 1201,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -4335,7 +6971,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1622:12:8",
+                    "src": "2663:12:8",
                     "tryCall": false,
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -4343,45 +6979,237 @@
                     }
                   },
                   "nodeType": "VariableDeclarationStatement",
-                  "src": "1605:29:8"
+                  "src": "2646:29:8"
+                },
+                {
+                  "assignments": [
+                    1204
+                  ],
+                  "declarations": [
+                    {
+                      "constant": false,
+                      "id": 1204,
+                      "mutability": "mutable",
+                      "name": "actualMinter",
+                      "nameLocation": "2693:12:8",
+                      "nodeType": "VariableDeclaration",
+                      "scope": 1222,
+                      "src": "2685:20:8",
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      },
+                      "typeName": {
+                        "id": 1203,
+                        "name": "address",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "2685:7:8",
+                        "stateMutability": "nonpayable",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      "visibility": "internal"
+                    }
+                  ],
+                  "id": 1208,
+                  "initialValue": {
+                    "arguments": [
+                      {
+                        "id": 1206,
+                        "name": "nftId",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 1186,
+                        "src": "2725:5:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      ],
+                      "id": 1205,
+                      "name": "_minterFromNftId",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 1321,
+                      "src": "2708:16:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_internal_pure$_t_uint256_$returns$_t_address_$",
+                        "typeString": "function (uint256) pure returns (address)"
+                      }
+                    },
+                    "id": 1207,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "2708:23:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "nodeType": "VariableDeclarationStatement",
+                  "src": "2685:46:8"
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "commonType": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        },
+                        "id": 1212,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "id": 1210,
+                          "name": "minter",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 1199,
+                          "src": "2749:6:8",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": "==",
+                        "rightExpression": {
+                          "id": 1211,
+                          "name": "actualMinter",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 1204,
+                          "src": "2759:12:8",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          }
+                        },
+                        "src": "2749:22:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      },
+                      {
+                        "hexValue": "4f6e6c79206d696e746572",
+                        "id": 1213,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "string",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "2773:13:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_stringliteral_578cb4a41adb75340d2cbfbdb0c6610ff4519d15e645cc9b4cc4c64336da99c6",
+                          "typeString": "literal_string \"Only minter\""
+                        },
+                        "value": "Only minter"
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        },
+                        {
+                          "typeIdentifier": "t_stringliteral_578cb4a41adb75340d2cbfbdb0c6610ff4519d15e645cc9b4cc4c64336da99c6",
+                          "typeString": "literal_string \"Only minter\""
+                        }
+                      ],
+                      "id": 1209,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        4294967278,
+                        4294967278
+                      ],
+                      "referencedDeclaration": 4294967278,
+                      "src": "2741:7:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
+                        "typeString": "function (bool,string memory) pure"
+                      }
+                    },
+                    "id": 1214,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "2741:46:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 1215,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2741:46:8"
                 },
                 {
                   "eventCall": {
                     "arguments": [
                       {
-                        "id": 1160,
-                        "name": "sender",
+                        "id": 1217,
+                        "name": "minter",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1155,
-                        "src": "1661:6:8",
+                        "referencedDeclaration": 1199,
+                        "src": "2820:6:8",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
                           "typeString": "address"
                         }
                       },
                       {
-                        "id": 1161,
+                        "id": 1218,
                         "name": "nftId",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1149,
-                        "src": "1669:5:8",
+                        "referencedDeclaration": 1186,
+                        "src": "2828:5:8",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
                         }
                       },
                       {
-                        "id": 1162,
-                        "name": "cid",
+                        "id": 1219,
+                        "name": "attachment",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1151,
-                        "src": "1676:3:8",
+                        "referencedDeclaration": 1188,
+                        "src": "2835:10:8",
                         "typeDescriptions": {
-                          "typeIdentifier": "t_bytes32",
-                          "typeString": "bytes32"
+                          "typeIdentifier": "t_bytes_calldata_ptr",
+                          "typeString": "bytes calldata"
                         }
                       }
                     ],
@@ -4396,22 +7224,22 @@
                           "typeString": "uint256"
                         },
                         {
-                          "typeIdentifier": "t_bytes32",
-                          "typeString": "bytes32"
+                          "typeIdentifier": "t_bytes_calldata_ptr",
+                          "typeString": "bytes calldata"
                         }
                       ],
-                      "id": 1159,
-                      "name": "AttachToNFT",
+                      "id": 1216,
+                      "name": "MinterAttachToNFT",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 1146,
-                      "src": "1649:11:8",
+                      "referencedDeclaration": 1165,
+                      "src": "2802:17:8",
                       "typeDescriptions": {
-                        "typeIdentifier": "t_function_event_nonpayable$_t_address_$_t_uint256_$_t_bytes32_$returns$__$",
-                        "typeString": "function (address,uint256,bytes32)"
+                        "typeIdentifier": "t_function_event_nonpayable$_t_address_$_t_uint256_$_t_bytes_memory_ptr_$returns$__$",
+                        "typeString": "function (address,uint256,bytes memory)"
                       }
                     },
-                    "id": 1163,
+                    "id": 1220,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -4419,46 +7247,46 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1649:31:8",
+                    "src": "2802:44:8",
                     "tryCall": false,
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 1164,
+                  "id": 1221,
                   "nodeType": "EmitStatement",
-                  "src": "1644:36:8"
+                  "src": "2797:49:8"
                 }
               ]
             },
             "documentation": {
-              "id": 1147,
+              "id": 1184,
               "nodeType": "StructuredDocumentation",
-              "src": "1293:237:8",
-              "text": "Attach an object identified by `cid` to the NFT type `nftId`.\n There is absolutely no validation. It is the responsibility of the reader of this event to decide\n who the sender is and what the object means."
+              "src": "2329:159:8",
+              "text": "Attach data `attachment` to the NFT type `nftId`, as the minter of this NFT type.\n This only works for NFT IDs in the Freeport format."
             },
-            "functionSelector": "ab278d19",
-            "id": 1166,
+            "functionSelector": "b85f8ca9",
+            "id": 1223,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
-            "name": "attachToNFT",
-            "nameLocation": "1544:11:8",
+            "name": "minterAttachToNFT",
+            "nameLocation": "2502:17:8",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1152,
+              "id": 1189,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1149,
+                  "id": 1186,
                   "mutability": "mutable",
                   "name": "nftId",
-                  "nameLocation": "1564:5:8",
+                  "nameLocation": "2528:5:8",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1166,
-                  "src": "1556:13:8",
+                  "scope": 1223,
+                  "src": "2520:13:8",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -4466,10 +7294,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1148,
+                    "id": 1185,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1556:7:8",
+                    "src": "2520:7:8",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -4479,83 +7307,1446 @@
                 },
                 {
                   "constant": false,
-                  "id": 1151,
+                  "id": 1188,
                   "mutability": "mutable",
-                  "name": "cid",
-                  "nameLocation": "1579:3:8",
+                  "name": "attachment",
+                  "nameLocation": "2550:10:8",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1166,
-                  "src": "1571:11:8",
+                  "scope": 1223,
+                  "src": "2535:25:8",
                   "stateVariable": false,
-                  "storageLocation": "default",
+                  "storageLocation": "calldata",
                   "typeDescriptions": {
-                    "typeIdentifier": "t_bytes32",
-                    "typeString": "bytes32"
+                    "typeIdentifier": "t_bytes_calldata_ptr",
+                    "typeString": "bytes"
                   },
                   "typeName": {
-                    "id": 1150,
-                    "name": "bytes32",
+                    "id": 1187,
+                    "name": "bytes",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1571:7:8",
+                    "src": "2535:5:8",
                     "typeDescriptions": {
-                      "typeIdentifier": "t_bytes32",
-                      "typeString": "bytes32"
+                      "typeIdentifier": "t_bytes_storage_ptr",
+                      "typeString": "bytes"
                     }
                   },
                   "visibility": "internal"
                 }
               ],
-              "src": "1555:28:8"
+              "src": "2519:42:8"
             },
             "returnParameters": {
-              "id": 1153,
+              "id": 1190,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "1595:0:8"
+              "src": "2573:0:8"
             },
-            "scope": 1167,
-            "src": "1535:152:8",
+            "scope": 1322,
+            "src": "2493:360:8",
             "stateMutability": "nonpayable",
+            "virtual": false,
+            "visibility": "public"
+          },
+          {
+            "body": {
+              "id": 1264,
+              "nodeType": "Block",
+              "src": "3120:277:8",
+              "statements": [
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "commonType": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        },
+                        "id": 1234,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "id": 1232,
+                          "name": "nftId",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 1226,
+                          "src": "3138:5:8",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": "!=",
+                        "rightExpression": {
+                          "id": 1233,
+                          "name": "CURRENCY",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 1132,
+                          "src": "3147:8:8",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        "src": "3138:17:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      },
+                      {
+                        "hexValue": "30206973206e6f7420612076616c6964204e4654204944",
+                        "id": 1235,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "string",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "3157:25:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_stringliteral_ae13f91217f47fbcc2b0198f394de1f4adce3e41753550c13e2321d5da6b1b56",
+                          "typeString": "literal_string \"0 is not a valid NFT ID\""
+                        },
+                        "value": "0 is not a valid NFT ID"
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        },
+                        {
+                          "typeIdentifier": "t_stringliteral_ae13f91217f47fbcc2b0198f394de1f4adce3e41753550c13e2321d5da6b1b56",
+                          "typeString": "literal_string \"0 is not a valid NFT ID\""
+                        }
+                      ],
+                      "id": 1231,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        4294967278,
+                        4294967278
+                      ],
+                      "referencedDeclaration": 4294967278,
+                      "src": "3130:7:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
+                        "typeString": "function (bool,string memory) pure"
+                      }
+                    },
+                    "id": 1236,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "3130:53:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 1237,
+                  "nodeType": "ExpressionStatement",
+                  "src": "3130:53:8"
+                },
+                {
+                  "assignments": [
+                    1239
+                  ],
+                  "declarations": [
+                    {
+                      "constant": false,
+                      "id": 1239,
+                      "mutability": "mutable",
+                      "name": "owner",
+                      "nameLocation": "3201:5:8",
+                      "nodeType": "VariableDeclaration",
+                      "scope": 1264,
+                      "src": "3193:13:8",
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      },
+                      "typeName": {
+                        "id": 1238,
+                        "name": "address",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "3193:7:8",
+                        "stateMutability": "nonpayable",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      "visibility": "internal"
+                    }
+                  ],
+                  "id": 1242,
+                  "initialValue": {
+                    "arguments": [],
+                    "expression": {
+                      "argumentTypes": [],
+                      "id": 1240,
+                      "name": "_msgSender",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        3136
+                      ],
+                      "referencedDeclaration": 3136,
+                      "src": "3209:10:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_internal_view$__$returns$_t_address_$",
+                        "typeString": "function () view returns (address)"
+                      }
+                    },
+                    "id": 1241,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "3209:12:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "nodeType": "VariableDeclarationStatement",
+                  "src": "3193:28:8"
+                },
+                {
+                  "assignments": [
+                    1244
+                  ],
+                  "declarations": [
+                    {
+                      "constant": false,
+                      "id": 1244,
+                      "mutability": "mutable",
+                      "name": "balance",
+                      "nameLocation": "3239:7:8",
+                      "nodeType": "VariableDeclaration",
+                      "scope": 1264,
+                      "src": "3231:15:8",
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      },
+                      "typeName": {
+                        "id": 1243,
+                        "name": "uint256",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "3231:7:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      },
+                      "visibility": "internal"
+                    }
+                  ],
+                  "id": 1250,
+                  "initialValue": {
+                    "arguments": [
+                      {
+                        "id": 1247,
+                        "name": "owner",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 1239,
+                        "src": "3268:5:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      {
+                        "id": 1248,
+                        "name": "nftId",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 1226,
+                        "src": "3275:5:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        },
+                        {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      ],
+                      "expression": {
+                        "id": 1245,
+                        "name": "freeport",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 1128,
+                        "src": "3249:8:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_contract$_Freeport_$947",
+                          "typeString": "contract Freeport"
+                        }
+                      },
+                      "id": 1246,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "lValueRequested": false,
+                      "memberName": "balanceOf",
+                      "nodeType": "MemberAccess",
+                      "referencedDeclaration": 4103,
+                      "src": "3249:18:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_external_view$_t_address_$_t_uint256_$returns$_t_uint256_$",
+                        "typeString": "function (address,uint256) view external returns (uint256)"
+                      }
+                    },
+                    "id": 1249,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "3249:32:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "nodeType": "VariableDeclarationStatement",
+                  "src": "3231:50:8"
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "commonType": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        },
+                        "id": 1254,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "id": 1252,
+                          "name": "balance",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 1244,
+                          "src": "3299:7:8",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": ">",
+                        "rightExpression": {
+                          "hexValue": "30",
+                          "id": 1253,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "number",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "3309:1:8",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_rational_0_by_1",
+                            "typeString": "int_const 0"
+                          },
+                          "value": "0"
+                        },
+                        "src": "3299:11:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      },
+                      {
+                        "hexValue": "4f6e6c792063757272656e74206f776e6572",
+                        "id": 1255,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "string",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "3312:20:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_stringliteral_111b7c5d2b16684041cedd75c064e2306dd9ae18e93fc76a7b5be4886458a40b",
+                          "typeString": "literal_string \"Only current owner\""
+                        },
+                        "value": "Only current owner"
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        },
+                        {
+                          "typeIdentifier": "t_stringliteral_111b7c5d2b16684041cedd75c064e2306dd9ae18e93fc76a7b5be4886458a40b",
+                          "typeString": "literal_string \"Only current owner\""
+                        }
+                      ],
+                      "id": 1251,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        4294967278,
+                        4294967278
+                      ],
+                      "referencedDeclaration": 4294967278,
+                      "src": "3291:7:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
+                        "typeString": "function (bool,string memory) pure"
+                      }
+                    },
+                    "id": 1256,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "3291:42:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 1257,
+                  "nodeType": "ExpressionStatement",
+                  "src": "3291:42:8"
+                },
+                {
+                  "eventCall": {
+                    "arguments": [
+                      {
+                        "id": 1259,
+                        "name": "owner",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 1239,
+                        "src": "3365:5:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      {
+                        "id": 1260,
+                        "name": "nftId",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 1226,
+                        "src": "3372:5:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      },
+                      {
+                        "id": 1261,
+                        "name": "attachment",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 1228,
+                        "src": "3379:10:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bytes_calldata_ptr",
+                          "typeString": "bytes calldata"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        },
+                        {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        },
+                        {
+                          "typeIdentifier": "t_bytes_calldata_ptr",
+                          "typeString": "bytes calldata"
+                        }
+                      ],
+                      "id": 1258,
+                      "name": "OwnerAttachToNFT",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 1174,
+                      "src": "3348:16:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_event_nonpayable$_t_address_$_t_uint256_$_t_bytes_memory_ptr_$returns$__$",
+                        "typeString": "function (address,uint256,bytes memory)"
+                      }
+                    },
+                    "id": 1262,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "3348:42:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 1263,
+                  "nodeType": "EmitStatement",
+                  "src": "3343:47:8"
+                }
+              ]
+            },
+            "documentation": {
+              "id": 1224,
+              "nodeType": "StructuredDocumentation",
+              "src": "2859:177:8",
+              "text": "Attach data `attachment` to the NFT type `nftId`, as a current owner of an NFT of this type.\n This works for NFTs in the ERC-1155 or Freeport standards."
+            },
+            "functionSelector": "c0ba9f55",
+            "id": 1265,
+            "implemented": true,
+            "kind": "function",
+            "modifiers": [],
+            "name": "ownerAttachToNFT",
+            "nameLocation": "3050:16:8",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 1229,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 1226,
+                  "mutability": "mutable",
+                  "name": "nftId",
+                  "nameLocation": "3075:5:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1265,
+                  "src": "3067:13:8",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 1225,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3067:7:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 1228,
+                  "mutability": "mutable",
+                  "name": "attachment",
+                  "nameLocation": "3097:10:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1265,
+                  "src": "3082:25:8",
+                  "stateVariable": false,
+                  "storageLocation": "calldata",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes_calldata_ptr",
+                    "typeString": "bytes"
+                  },
+                  "typeName": {
+                    "id": 1227,
+                    "name": "bytes",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3082:5:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes_storage_ptr",
+                      "typeString": "bytes"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3066:42:8"
+            },
+            "returnParameters": {
+              "id": 1230,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "3120:0:8"
+            },
+            "scope": 1322,
+            "src": "3041:356:8",
+            "stateMutability": "nonpayable",
+            "virtual": false,
+            "visibility": "public"
+          },
+          {
+            "body": {
+              "id": 1291,
+              "nodeType": "Block",
+              "src": "3565:168:8",
+              "statements": [
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "commonType": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        },
+                        "id": 1276,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "id": 1274,
+                          "name": "nftId",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 1268,
+                          "src": "3583:5:8",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": "!=",
+                        "rightExpression": {
+                          "id": 1275,
+                          "name": "CURRENCY",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 1132,
+                          "src": "3592:8:8",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        "src": "3583:17:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      },
+                      {
+                        "hexValue": "30206973206e6f7420612076616c6964204e4654204944",
+                        "id": 1277,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "string",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "3602:25:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_stringliteral_ae13f91217f47fbcc2b0198f394de1f4adce3e41753550c13e2321d5da6b1b56",
+                          "typeString": "literal_string \"0 is not a valid NFT ID\""
+                        },
+                        "value": "0 is not a valid NFT ID"
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        },
+                        {
+                          "typeIdentifier": "t_stringliteral_ae13f91217f47fbcc2b0198f394de1f4adce3e41753550c13e2321d5da6b1b56",
+                          "typeString": "literal_string \"0 is not a valid NFT ID\""
+                        }
+                      ],
+                      "id": 1273,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        4294967278,
+                        4294967278
+                      ],
+                      "referencedDeclaration": 4294967278,
+                      "src": "3575:7:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
+                        "typeString": "function (bool,string memory) pure"
+                      }
+                    },
+                    "id": 1278,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "3575:53:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 1279,
+                  "nodeType": "ExpressionStatement",
+                  "src": "3575:53:8"
+                },
+                {
+                  "assignments": [
+                    1281
+                  ],
+                  "declarations": [
+                    {
+                      "constant": false,
+                      "id": 1281,
+                      "mutability": "mutable",
+                      "name": "anonym",
+                      "nameLocation": "3646:6:8",
+                      "nodeType": "VariableDeclaration",
+                      "scope": 1291,
+                      "src": "3638:14:8",
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      },
+                      "typeName": {
+                        "id": 1280,
+                        "name": "address",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "3638:7:8",
+                        "stateMutability": "nonpayable",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      "visibility": "internal"
+                    }
+                  ],
+                  "id": 1284,
+                  "initialValue": {
+                    "arguments": [],
+                    "expression": {
+                      "argumentTypes": [],
+                      "id": 1282,
+                      "name": "_msgSender",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        3136
+                      ],
+                      "referencedDeclaration": 3136,
+                      "src": "3655:10:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_internal_view$__$returns$_t_address_$",
+                        "typeString": "function () view returns (address)"
+                      }
+                    },
+                    "id": 1283,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "3655:12:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "nodeType": "VariableDeclarationStatement",
+                  "src": "3638:29:8"
+                },
+                {
+                  "eventCall": {
+                    "arguments": [
+                      {
+                        "id": 1286,
+                        "name": "anonym",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 1281,
+                        "src": "3700:6:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      {
+                        "id": 1287,
+                        "name": "nftId",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 1268,
+                        "src": "3708:5:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      },
+                      {
+                        "id": 1288,
+                        "name": "attachment",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 1270,
+                        "src": "3715:10:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bytes_calldata_ptr",
+                          "typeString": "bytes calldata"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        },
+                        {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        },
+                        {
+                          "typeIdentifier": "t_bytes_calldata_ptr",
+                          "typeString": "bytes calldata"
+                        }
+                      ],
+                      "id": 1285,
+                      "name": "AnonymAttachToNFT",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 1183,
+                      "src": "3682:17:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_event_nonpayable$_t_address_$_t_uint256_$_t_bytes_memory_ptr_$returns$__$",
+                        "typeString": "function (address,uint256,bytes memory)"
+                      }
+                    },
+                    "id": 1289,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "3682:44:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 1290,
+                  "nodeType": "EmitStatement",
+                  "src": "3677:49:8"
+                }
+              ]
+            },
+            "documentation": {
+              "id": 1266,
+              "nodeType": "StructuredDocumentation",
+              "src": "3403:77:8",
+              "text": "Attach data `attachment` to the NFT type `nftId`, as any account."
+            },
+            "functionSelector": "f9715b8f",
+            "id": 1292,
+            "implemented": true,
+            "kind": "function",
+            "modifiers": [],
+            "name": "anonymAttachToNFT",
+            "nameLocation": "3494:17:8",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 1271,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 1268,
+                  "mutability": "mutable",
+                  "name": "nftId",
+                  "nameLocation": "3520:5:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1292,
+                  "src": "3512:13:8",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 1267,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3512:7:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 1270,
+                  "mutability": "mutable",
+                  "name": "attachment",
+                  "nameLocation": "3542:10:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1292,
+                  "src": "3527:25:8",
+                  "stateVariable": false,
+                  "storageLocation": "calldata",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes_calldata_ptr",
+                    "typeString": "bytes"
+                  },
+                  "typeName": {
+                    "id": 1269,
+                    "name": "bytes",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3527:5:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes_storage_ptr",
+                      "typeString": "bytes"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3511:42:8"
+            },
+            "returnParameters": {
+              "id": 1272,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "3565:0:8"
+            },
+            "scope": 1322,
+            "src": "3485:248:8",
+            "stateMutability": "nonpayable",
+            "virtual": false,
+            "visibility": "public"
+          },
+          {
+            "body": {
+              "id": 1320,
+              "nodeType": "Block",
+              "src": "4040:153:8",
+              "statements": [
+                {
+                  "expression": {
+                    "id": 1316,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "id": 1300,
+                      "name": "minter",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 1298,
+                      "src": "4050:6:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "arguments": [
+                        {
+                          "arguments": [
+                            {
+                              "commonType": {
+                                "typeIdentifier": "t_uint256",
+                                "typeString": "uint256"
+                              },
+                              "id": 1313,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "leftExpression": {
+                                "components": [
+                                  {
+                                    "commonType": {
+                                      "typeIdentifier": "t_uint256",
+                                      "typeString": "uint256"
+                                    },
+                                    "id": 1307,
+                                    "isConstant": false,
+                                    "isLValue": false,
+                                    "isPure": false,
+                                    "lValueRequested": false,
+                                    "leftExpression": {
+                                      "id": 1305,
+                                      "name": "id",
+                                      "nodeType": "Identifier",
+                                      "overloadedDeclarations": [],
+                                      "referencedDeclaration": 1295,
+                                      "src": "4076:2:8",
+                                      "typeDescriptions": {
+                                        "typeIdentifier": "t_uint256",
+                                        "typeString": "uint256"
+                                      }
+                                    },
+                                    "nodeType": "BinaryOperation",
+                                    "operator": "&",
+                                    "rightExpression": {
+                                      "hexValue": "307846464646464646464646464646464646464646464646464646464646464646464646464646464646303030303030303030303030303030303030303030303030",
+                                      "id": 1306,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "kind": "number",
+                                      "lValueRequested": false,
+                                      "nodeType": "Literal",
+                                      "src": "4081:66:8",
+                                      "typeDescriptions": {
+                                        "typeIdentifier": "t_rational_115792089237316195423570985008687907853269984665561335876943319670319585689600_by_1",
+                                        "typeString": "int_const 1157...(70 digits omitted)...9600"
+                                      },
+                                      "value": "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000000000000000"
+                                    },
+                                    "src": "4076:71:8",
+                                    "typeDescriptions": {
+                                      "typeIdentifier": "t_uint256",
+                                      "typeString": "uint256"
+                                    }
+                                  }
+                                ],
+                                "id": 1308,
+                                "isConstant": false,
+                                "isInlineArray": false,
+                                "isLValue": false,
+                                "isPure": false,
+                                "lValueRequested": false,
+                                "nodeType": "TupleExpression",
+                                "src": "4075:73:8",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_uint256",
+                                  "typeString": "uint256"
+                                }
+                              },
+                              "nodeType": "BinaryOperation",
+                              "operator": ">>",
+                              "rightExpression": {
+                                "components": [
+                                  {
+                                    "commonType": {
+                                      "typeIdentifier": "t_rational_96_by_1",
+                                      "typeString": "int_const 96"
+                                    },
+                                    "id": 1311,
+                                    "isConstant": false,
+                                    "isLValue": false,
+                                    "isPure": true,
+                                    "lValueRequested": false,
+                                    "leftExpression": {
+                                      "hexValue": "3332",
+                                      "id": 1309,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "kind": "number",
+                                      "lValueRequested": false,
+                                      "nodeType": "Literal",
+                                      "src": "4153:2:8",
+                                      "typeDescriptions": {
+                                        "typeIdentifier": "t_rational_32_by_1",
+                                        "typeString": "int_const 32"
+                                      },
+                                      "value": "32"
+                                    },
+                                    "nodeType": "BinaryOperation",
+                                    "operator": "+",
+                                    "rightExpression": {
+                                      "hexValue": "3634",
+                                      "id": 1310,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "kind": "number",
+                                      "lValueRequested": false,
+                                      "nodeType": "Literal",
+                                      "src": "4158:2:8",
+                                      "typeDescriptions": {
+                                        "typeIdentifier": "t_rational_64_by_1",
+                                        "typeString": "int_const 64"
+                                      },
+                                      "value": "64"
+                                    },
+                                    "src": "4153:7:8",
+                                    "typeDescriptions": {
+                                      "typeIdentifier": "t_rational_96_by_1",
+                                      "typeString": "int_const 96"
+                                    }
+                                  }
+                                ],
+                                "id": 1312,
+                                "isConstant": false,
+                                "isInlineArray": false,
+                                "isLValue": false,
+                                "isPure": true,
+                                "lValueRequested": false,
+                                "nodeType": "TupleExpression",
+                                "src": "4152:9:8",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_rational_96_by_1",
+                                  "typeString": "int_const 96"
+                                }
+                              },
+                              "src": "4075:86:8",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_uint256",
+                                "typeString": "uint256"
+                              }
+                            }
+                          ],
+                          "expression": {
+                            "argumentTypes": [
+                              {
+                                "typeIdentifier": "t_uint256",
+                                "typeString": "uint256"
+                              }
+                            ],
+                            "id": 1304,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "lValueRequested": false,
+                            "nodeType": "ElementaryTypeNameExpression",
+                            "src": "4067:7:8",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_type$_t_uint160_$",
+                              "typeString": "type(uint160)"
+                            },
+                            "typeName": {
+                              "id": 1303,
+                              "name": "uint160",
+                              "nodeType": "ElementaryTypeName",
+                              "src": "4067:7:8",
+                              "typeDescriptions": {}
+                            }
+                          },
+                          "id": 1314,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "kind": "typeConversion",
+                          "lValueRequested": false,
+                          "names": [],
+                          "nodeType": "FunctionCall",
+                          "src": "4067:95:8",
+                          "tryCall": false,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint160",
+                            "typeString": "uint160"
+                          }
+                        }
+                      ],
+                      "expression": {
+                        "argumentTypes": [
+                          {
+                            "typeIdentifier": "t_uint160",
+                            "typeString": "uint160"
+                          }
+                        ],
+                        "id": 1302,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "lValueRequested": false,
+                        "nodeType": "ElementaryTypeNameExpression",
+                        "src": "4059:7:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_type$_t_address_$",
+                          "typeString": "type(address)"
+                        },
+                        "typeName": {
+                          "id": 1301,
+                          "name": "address",
+                          "nodeType": "ElementaryTypeName",
+                          "src": "4059:7:8",
+                          "typeDescriptions": {}
+                        }
+                      },
+                      "id": 1315,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "kind": "typeConversion",
+                      "lValueRequested": false,
+                      "names": [],
+                      "nodeType": "FunctionCall",
+                      "src": "4059:104:8",
+                      "tryCall": false,
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "src": "4050:113:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "id": 1317,
+                  "nodeType": "ExpressionStatement",
+                  "src": "4050:113:8"
+                },
+                {
+                  "expression": {
+                    "id": 1318,
+                    "name": "minter",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "referencedDeclaration": 1298,
+                    "src": "4180:6:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "functionReturnParameters": 1299,
+                  "id": 1319,
+                  "nodeType": "Return",
+                  "src": "4173:13:8"
+                }
+              ]
+            },
+            "documentation": {
+              "id": 1293,
+              "nodeType": "StructuredDocumentation",
+              "src": "3739:217:8",
+              "text": "Parse an NFT ID into its issuer, its supply, and an arbitrary nonce.\n This does not imply that the NFTs exist.\n This is specific to Freeport NFTs. See `freeportParts/Issuance.sol`"
+            },
+            "functionSelector": "d2e9277b",
+            "id": 1321,
+            "implemented": true,
+            "kind": "function",
+            "modifiers": [],
+            "name": "_minterFromNftId",
+            "nameLocation": "3970:16:8",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 1296,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 1295,
+                  "mutability": "mutable",
+                  "name": "id",
+                  "nameLocation": "3995:2:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1321,
+                  "src": "3987:10:8",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 1294,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3987:7:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3986:12:8"
+            },
+            "returnParameters": {
+              "id": 1299,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 1298,
+                  "mutability": "mutable",
+                  "name": "minter",
+                  "nameLocation": "4032:6:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1321,
+                  "src": "4024:14:8",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 1297,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "4024:7:8",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "4023:16:8"
+            },
+            "scope": 1322,
+            "src": "3961:232:8",
+            "stateMutability": "pure",
             "virtual": false,
             "visibility": "public"
           }
         ],
-        "scope": 1168,
-        "src": "537:1152:8",
+        "scope": 1323,
+        "src": "626:3569:8",
         "usedErrors": []
       }
     ],
-    "src": "0:1690:8"
+    "src": "0:4196:8"
   },
   "legacyAST": {
     "absolutePath": "project:/contracts/NFTAttachment.sol",
     "exportedSymbols": {
       "AccessControl": [
-        2024
+        2208
+      ],
+      "Address": [
+        5579
+      ],
+      "BaseNFT": [
+        2338
       ],
       "Context": [
-        5418
+        5602
+      ],
+      "Currency": [
+        2405
+      ],
+      "ERC1155": [
+        5020
       ],
       "ERC165": [
-        5927
+        6111
+      ],
+      "ERC20Adapter": [
+        2503
+      ],
+      "Freeport": [
+        947
       ],
       "IAccessControl": [
-        1700
+        1884
+      ],
+      "IERC1155": [
+        5142
+      ],
+      "IERC1155MetadataURI": [
+        5198
+      ],
+      "IERC1155Receiver": [
+        5183
       ],
       "IERC165": [
-        5939
+        6123
+      ],
+      "IERC20": [
+        584
+      ],
+      "Issuance": [
+        2757
+      ],
+      "JointAccounts": [
+        3094
       ],
       "MetaTxContext": [
-        2980
+        3164
       ],
       "NFTAttachment": [
-        1167
+        1322
+      ],
+      "SimpleExchange": [
+        3341
       ],
       "Strings": [
-        5621
+        5805
+      ],
+      "TransferFees": [
+        3950
+      ],
+      "TransferOperator": [
+        3987
       ]
     },
-    "id": 1168,
+    "id": 1323,
     "nodeType": "SourceUnit",
     "nodes": [
       {
@@ -4575,9 +8766,21 @@
         "id": 1120,
         "nameLocation": "-1:-1:-1",
         "nodeType": "ImportDirective",
-        "scope": 1168,
-        "sourceUnit": 2981,
+        "scope": 1323,
+        "sourceUnit": 3165,
         "src": "25:43:8",
+        "symbolAliases": [],
+        "unitAlias": ""
+      },
+      {
+        "absolutePath": "project:/contracts/Freeport.sol",
+        "file": "./Freeport.sol",
+        "id": 1121,
+        "nameLocation": "-1:-1:-1",
+        "nodeType": "ImportDirective",
+        "scope": 1323,
+        "sourceUnit": 948,
+        "src": "69:24:8",
         "symbolAliases": [],
         "unitAlias": ""
       },
@@ -4586,133 +8789,366 @@
         "baseContracts": [
           {
             "baseName": {
-              "id": 1122,
+              "id": 1123,
               "name": "MetaTxContext",
               "nodeType": "IdentifierPath",
-              "referencedDeclaration": 2980,
-              "src": "584:13:8"
+              "referencedDeclaration": 3164,
+              "src": "673:13:8"
             },
-            "id": 1123,
+            "id": 1124,
             "nodeType": "InheritanceSpecifier",
-            "src": "584:13:8"
+            "src": "673:13:8"
           }
         ],
         "contractDependencies": [],
         "contractKind": "contract",
         "documentation": {
-          "id": 1121,
+          "id": 1122,
           "nodeType": "StructuredDocumentation",
-          "src": "70:466:8",
-          "text": "The contract NFTAttachment allows users to attach objects to NFTs.\n Some application can listen for the events and interpret the objects in some way.\n Anyone can attach objects to any NFT. It is the responsibility of the app to\n interpret who the sender is and what the object means.\n An object is identified by CID, a.k.a. Content Identifier or IPFS file, of maximum 32 bytes.\n The content may be retrieved from Cere DDC or some other store."
+          "src": "95:530:8",
+          "text": "The contract NFTAttachment allows users to attach objects to NFTs.\n Some application can listen for the events and interpret the objects in some way.\n There are three roles who can attach objects to an NFT:\n the minter, any current owner, or any anonymous account.\n A different event is emitted for each role.\n The attachment data is meant to identify an object hosted externally,\n such as a CID, a.k.a. Content Identifier, or a DDC URL.\n The content may be retrieved from Cere DDC or some other store."
         },
         "fullyImplemented": true,
-        "id": 1167,
+        "id": 1322,
         "linearizedBaseContracts": [
-          1167,
-          2980,
-          2024,
-          5927,
-          5939,
-          1700,
-          5418
+          1322,
+          3164,
+          2208,
+          6111,
+          6123,
+          1884,
+          5602
         ],
         "name": "NFTAttachment",
-        "nameLocation": "546:13:8",
+        "nameLocation": "635:13:8",
         "nodeType": "ContractDefinition",
         "nodes": [
           {
             "constant": false,
             "documentation": {
-              "id": 1124,
+              "id": 1125,
               "nodeType": "StructuredDocumentation",
-              "src": "605:133:8",
-              "text": "This attachment contract refers to the NFT contract in this variable.\n This is informative, there is no validation."
+              "src": "694:81:8",
+              "text": "This attachment contract refers to the NFT contract in this variable."
             },
-            "functionSelector": "d56d229d",
-            "id": 1126,
+            "functionSelector": "9470ad85",
+            "id": 1128,
             "mutability": "mutable",
-            "name": "nftContract",
-            "nameLocation": "758:11:8",
+            "name": "freeport",
+            "nameLocation": "796:8:8",
             "nodeType": "VariableDeclaration",
-            "scope": 1167,
-            "src": "743:26:8",
+            "scope": 1322,
+            "src": "780:24:8",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
-              "typeIdentifier": "t_address",
-              "typeString": "address"
+              "typeIdentifier": "t_contract$_Freeport_$947",
+              "typeString": "contract Freeport"
             },
             "typeName": {
-              "id": 1125,
-              "name": "address",
-              "nodeType": "ElementaryTypeName",
-              "src": "743:7:8",
-              "stateMutability": "nonpayable",
+              "id": 1127,
+              "nodeType": "UserDefinedTypeName",
+              "pathNode": {
+                "id": 1126,
+                "name": "Freeport",
+                "nodeType": "IdentifierPath",
+                "referencedDeclaration": 947,
+                "src": "780:8:8"
+              },
+              "referencedDeclaration": 947,
+              "src": "780:8:8",
               "typeDescriptions": {
-                "typeIdentifier": "t_address",
-                "typeString": "address"
+                "typeIdentifier": "t_contract$_Freeport_$947",
+                "typeString": "contract Freeport"
               }
             },
             "visibility": "public"
           },
           {
+            "constant": true,
+            "documentation": {
+              "id": 1129,
+              "nodeType": "StructuredDocumentation",
+              "src": "811:87:8",
+              "text": "The token ID that represents the internal currency for all payments in Freeport. "
+            },
+            "id": 1132,
+            "mutability": "constant",
+            "name": "CURRENCY",
+            "nameLocation": "920:8:8",
+            "nodeType": "VariableDeclaration",
+            "scope": 1322,
+            "src": "903:29:8",
+            "stateVariable": true,
+            "storageLocation": "default",
+            "typeDescriptions": {
+              "typeIdentifier": "t_uint256",
+              "typeString": "uint256"
+            },
+            "typeName": {
+              "id": 1130,
+              "name": "uint256",
+              "nodeType": "ElementaryTypeName",
+              "src": "903:7:8",
+              "typeDescriptions": {
+                "typeIdentifier": "t_uint256",
+                "typeString": "uint256"
+              }
+            },
+            "value": {
+              "hexValue": "30",
+              "id": 1131,
+              "isConstant": false,
+              "isLValue": false,
+              "isPure": true,
+              "kind": "number",
+              "lValueRequested": false,
+              "nodeType": "Literal",
+              "src": "931:1:8",
+              "typeDescriptions": {
+                "typeIdentifier": "t_rational_0_by_1",
+                "typeString": "int_const 0"
+              },
+              "value": "0"
+            },
+            "visibility": "internal"
+          },
+          {
             "body": {
-              "id": 1136,
+              "id": 1155,
               "nodeType": "Block",
-              "src": "862:43:8",
+              "src": "1210:88:8",
               "statements": [
                 {
                   "expression": {
-                    "id": 1134,
+                    "arguments": [
+                      {
+                        "commonType": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        },
+                        "id": 1148,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "arguments": [
+                            {
+                              "id": 1142,
+                              "name": "_freeport",
+                              "nodeType": "Identifier",
+                              "overloadedDeclarations": [],
+                              "referencedDeclaration": 1136,
+                              "src": "1236:9:8",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_contract$_Freeport_$947",
+                                "typeString": "contract Freeport"
+                              }
+                            }
+                          ],
+                          "expression": {
+                            "argumentTypes": [
+                              {
+                                "typeIdentifier": "t_contract$_Freeport_$947",
+                                "typeString": "contract Freeport"
+                              }
+                            ],
+                            "id": 1141,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "lValueRequested": false,
+                            "nodeType": "ElementaryTypeNameExpression",
+                            "src": "1228:7:8",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_type$_t_address_$",
+                              "typeString": "type(address)"
+                            },
+                            "typeName": {
+                              "id": 1140,
+                              "name": "address",
+                              "nodeType": "ElementaryTypeName",
+                              "src": "1228:7:8",
+                              "typeDescriptions": {}
+                            }
+                          },
+                          "id": 1143,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "kind": "typeConversion",
+                          "lValueRequested": false,
+                          "names": [],
+                          "nodeType": "FunctionCall",
+                          "src": "1228:18:8",
+                          "tryCall": false,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": "!=",
+                        "rightExpression": {
+                          "arguments": [
+                            {
+                              "hexValue": "30",
+                              "id": 1146,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": true,
+                              "kind": "number",
+                              "lValueRequested": false,
+                              "nodeType": "Literal",
+                              "src": "1258:1:8",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_rational_0_by_1",
+                                "typeString": "int_const 0"
+                              },
+                              "value": "0"
+                            }
+                          ],
+                          "expression": {
+                            "argumentTypes": [
+                              {
+                                "typeIdentifier": "t_rational_0_by_1",
+                                "typeString": "int_const 0"
+                              }
+                            ],
+                            "id": 1145,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "lValueRequested": false,
+                            "nodeType": "ElementaryTypeNameExpression",
+                            "src": "1250:7:8",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_type$_t_address_$",
+                              "typeString": "type(address)"
+                            },
+                            "typeName": {
+                              "id": 1144,
+                              "name": "address",
+                              "nodeType": "ElementaryTypeName",
+                              "src": "1250:7:8",
+                              "typeDescriptions": {}
+                            }
+                          },
+                          "id": 1147,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "typeConversion",
+                          "lValueRequested": false,
+                          "names": [],
+                          "nodeType": "FunctionCall",
+                          "src": "1250:10:8",
+                          "tryCall": false,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          }
+                        },
+                        "src": "1228:32:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      ],
+                      "id": 1139,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        4294967278,
+                        4294967278
+                      ],
+                      "referencedDeclaration": 4294967278,
+                      "src": "1220:7:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$returns$__$",
+                        "typeString": "function (bool) pure"
+                      }
+                    },
+                    "id": 1149,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "1220:41:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 1150,
+                  "nodeType": "ExpressionStatement",
+                  "src": "1220:41:8"
+                },
+                {
+                  "expression": {
+                    "id": 1153,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
-                      "id": 1132,
-                      "name": "nftContract",
+                      "id": 1151,
+                      "name": "freeport",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 1126,
-                      "src": "872:11:8",
+                      "referencedDeclaration": 1128,
+                      "src": "1271:8:8",
                       "typeDescriptions": {
-                        "typeIdentifier": "t_address",
-                        "typeString": "address"
+                        "typeIdentifier": "t_contract$_Freeport_$947",
+                        "typeString": "contract Freeport"
                       }
                     },
                     "nodeType": "Assignment",
                     "operator": "=",
                     "rightHandSide": {
-                      "id": 1133,
-                      "name": "_nftContract",
+                      "id": 1152,
+                      "name": "_freeport",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 1129,
-                      "src": "886:12:8",
+                      "referencedDeclaration": 1136,
+                      "src": "1282:9:8",
                       "typeDescriptions": {
-                        "typeIdentifier": "t_address",
-                        "typeString": "address"
+                        "typeIdentifier": "t_contract$_Freeport_$947",
+                        "typeString": "contract Freeport"
                       }
                     },
-                    "src": "872:26:8",
+                    "src": "1271:20:8",
                     "typeDescriptions": {
-                      "typeIdentifier": "t_address",
-                      "typeString": "address"
+                      "typeIdentifier": "t_contract$_Freeport_$947",
+                      "typeString": "contract Freeport"
                     }
                   },
-                  "id": 1135,
+                  "id": 1154,
                   "nodeType": "ExpressionStatement",
-                  "src": "872:26:8"
+                  "src": "1271:20:8"
                 }
               ]
             },
             "documentation": {
-              "id": 1127,
+              "id": 1133,
               "nodeType": "StructuredDocumentation",
-              "src": "776:47:8",
-              "text": "Set which NFT contract to refer to."
+              "src": "939:234:8",
+              "text": "Set which NFT contract to refer to.\n The event `MinterAttachToNFT` is only supported for Freeport-compatible NFTs.\n The event `OwnerAttachToNFT` is supported for ERC-1155 NFTs, including Freeport."
             },
-            "id": 1137,
+            "id": 1156,
             "implemented": true,
             "kind": "constructor",
             "modifiers": [],
@@ -4720,48 +9156,54 @@
             "nameLocation": "-1:-1:-1",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1130,
+              "id": 1137,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1129,
+                  "id": 1136,
                   "mutability": "mutable",
-                  "name": "_nftContract",
-                  "nameLocation": "848:12:8",
+                  "name": "_freeport",
+                  "nameLocation": "1199:9:8",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1137,
-                  "src": "840:20:8",
+                  "scope": 1156,
+                  "src": "1190:18:8",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
-                    "typeIdentifier": "t_address",
-                    "typeString": "address"
+                    "typeIdentifier": "t_contract$_Freeport_$947",
+                    "typeString": "contract Freeport"
                   },
                   "typeName": {
-                    "id": 1128,
-                    "name": "address",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "840:7:8",
-                    "stateMutability": "nonpayable",
+                    "id": 1135,
+                    "nodeType": "UserDefinedTypeName",
+                    "pathNode": {
+                      "id": 1134,
+                      "name": "Freeport",
+                      "nodeType": "IdentifierPath",
+                      "referencedDeclaration": 947,
+                      "src": "1190:8:8"
+                    },
+                    "referencedDeclaration": 947,
+                    "src": "1190:8:8",
                     "typeDescriptions": {
-                      "typeIdentifier": "t_address",
-                      "typeString": "address"
+                      "typeIdentifier": "t_contract$_Freeport_$947",
+                      "typeString": "contract Freeport"
                     }
                   },
                   "visibility": "internal"
                 }
               ],
-              "src": "839:22:8"
+              "src": "1189:20:8"
             },
             "returnParameters": {
-              "id": 1131,
+              "id": 1138,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "862:0:8"
+              "src": "1210:0:8"
             },
-            "scope": 1167,
-            "src": "828:77:8",
+            "scope": 1322,
+            "src": "1178:120:8",
             "stateMutability": "nonpayable",
             "virtual": false,
             "visibility": "public"
@@ -4769,29 +9211,29 @@
           {
             "anonymous": false,
             "documentation": {
-              "id": 1138,
+              "id": 1157,
               "nodeType": "StructuredDocumentation",
-              "src": "911:268:8",
-              "text": "The account `sender` wished to attach an object identified by `cid` to the NFT type `nftId`.\n There is absolutely no validation. It is the responsibility of the reader of this event to decide\n who the sender is and what the object means."
+              "src": "1304:213:8",
+              "text": "The account `minter` wished to attach data `attachment` to the NFT type `nftId`.\n The `minter` is the minter who created this NFT type, or may create it in the future if it does not exist."
             },
-            "id": 1146,
-            "name": "AttachToNFT",
-            "nameLocation": "1190:11:8",
+            "id": 1165,
+            "name": "MinterAttachToNFT",
+            "nameLocation": "1528:17:8",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 1145,
+              "id": 1164,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1140,
+                  "id": 1159,
                   "indexed": true,
                   "mutability": "mutable",
-                  "name": "sender",
-                  "nameLocation": "1227:6:8",
+                  "name": "minter",
+                  "nameLocation": "1571:6:8",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1146,
-                  "src": "1211:22:8",
+                  "scope": 1165,
+                  "src": "1555:22:8",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -4799,10 +9241,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1139,
+                    "id": 1158,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1211:7:8",
+                    "src": "1555:7:8",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -4813,14 +9255,14 @@
                 },
                 {
                   "constant": false,
-                  "id": 1142,
+                  "id": 1161,
                   "indexed": true,
                   "mutability": "mutable",
                   "name": "nftId",
-                  "nameLocation": "1259:5:8",
+                  "nameLocation": "1603:5:8",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1146,
-                  "src": "1243:21:8",
+                  "scope": 1165,
+                  "src": "1587:21:8",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -4828,10 +9270,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1141,
+                    "id": 1160,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1243:7:8",
+                    "src": "1587:7:8",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -4841,57 +9283,375 @@
                 },
                 {
                   "constant": false,
-                  "id": 1144,
+                  "id": 1163,
                   "indexed": false,
                   "mutability": "mutable",
-                  "name": "cid",
-                  "nameLocation": "1282:3:8",
+                  "name": "attachment",
+                  "nameLocation": "1624:10:8",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1146,
-                  "src": "1274:11:8",
+                  "scope": 1165,
+                  "src": "1618:16:8",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
-                    "typeIdentifier": "t_bytes32",
-                    "typeString": "bytes32"
+                    "typeIdentifier": "t_bytes_memory_ptr",
+                    "typeString": "bytes"
                   },
                   "typeName": {
-                    "id": 1143,
-                    "name": "bytes32",
+                    "id": 1162,
+                    "name": "bytes",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1274:7:8",
+                    "src": "1618:5:8",
                     "typeDescriptions": {
-                      "typeIdentifier": "t_bytes32",
-                      "typeString": "bytes32"
+                      "typeIdentifier": "t_bytes_storage_ptr",
+                      "typeString": "bytes"
                     }
                   },
                   "visibility": "internal"
                 }
               ],
-              "src": "1201:85:8"
+              "src": "1545:90:8"
             },
-            "src": "1184:103:8"
+            "src": "1522:114:8"
+          },
+          {
+            "anonymous": false,
+            "documentation": {
+              "id": 1166,
+              "nodeType": "StructuredDocumentation",
+              "src": "1642:179:8",
+              "text": "The account `owner` wished to attach data `attachment` to the NFT type `nftId`.\n The `owner` owned at least one NFT of this type at the time of the event."
+            },
+            "id": 1174,
+            "name": "OwnerAttachToNFT",
+            "nameLocation": "1832:16:8",
+            "nodeType": "EventDefinition",
+            "parameters": {
+              "id": 1173,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 1168,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "owner",
+                  "nameLocation": "1874:5:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1174,
+                  "src": "1858:21:8",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 1167,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1858:7:8",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 1170,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "nftId",
+                  "nameLocation": "1905:5:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1174,
+                  "src": "1889:21:8",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 1169,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1889:7:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 1172,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "attachment",
+                  "nameLocation": "1926:10:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1174,
+                  "src": "1920:16:8",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes_memory_ptr",
+                    "typeString": "bytes"
+                  },
+                  "typeName": {
+                    "id": 1171,
+                    "name": "bytes",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "1920:5:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes_storage_ptr",
+                      "typeString": "bytes"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "1848:89:8"
+            },
+            "src": "1826:112:8"
+          },
+          {
+            "anonymous": false,
+            "documentation": {
+              "id": 1175,
+              "nodeType": "StructuredDocumentation",
+              "src": "1944:260:8",
+              "text": "The account `anonym` wished to attach data `attachment` to the NFT type `nftId`.\n There is absolutely no validation. It is the responsibility of the reader of this event to decide\n who the sender is and what the attachment means."
+            },
+            "id": 1183,
+            "name": "AnonymAttachToNFT",
+            "nameLocation": "2215:17:8",
+            "nodeType": "EventDefinition",
+            "parameters": {
+              "id": 1182,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 1177,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "anonym",
+                  "nameLocation": "2258:6:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1183,
+                  "src": "2242:22:8",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 1176,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2242:7:8",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 1179,
+                  "indexed": true,
+                  "mutability": "mutable",
+                  "name": "nftId",
+                  "nameLocation": "2290:5:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1183,
+                  "src": "2274:21:8",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 1178,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2274:7:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 1181,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "attachment",
+                  "nameLocation": "2311:10:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1183,
+                  "src": "2305:16:8",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes_memory_ptr",
+                    "typeString": "bytes"
+                  },
+                  "typeName": {
+                    "id": 1180,
+                    "name": "bytes",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2305:5:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes_storage_ptr",
+                      "typeString": "bytes"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "2232:90:8"
+            },
+            "src": "2209:114:8"
           },
           {
             "body": {
-              "id": 1165,
+              "id": 1222,
               "nodeType": "Block",
-              "src": "1595:92:8",
+              "src": "2573:280:8",
               "statements": [
                 {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "commonType": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        },
+                        "id": 1194,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "id": 1192,
+                          "name": "nftId",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 1186,
+                          "src": "2591:5:8",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": "!=",
+                        "rightExpression": {
+                          "id": 1193,
+                          "name": "CURRENCY",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 1132,
+                          "src": "2600:8:8",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        "src": "2591:17:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      },
+                      {
+                        "hexValue": "30206973206e6f7420612076616c6964204e4654204944",
+                        "id": 1195,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "string",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "2610:25:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_stringliteral_ae13f91217f47fbcc2b0198f394de1f4adce3e41753550c13e2321d5da6b1b56",
+                          "typeString": "literal_string \"0 is not a valid NFT ID\""
+                        },
+                        "value": "0 is not a valid NFT ID"
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        },
+                        {
+                          "typeIdentifier": "t_stringliteral_ae13f91217f47fbcc2b0198f394de1f4adce3e41753550c13e2321d5da6b1b56",
+                          "typeString": "literal_string \"0 is not a valid NFT ID\""
+                        }
+                      ],
+                      "id": 1191,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        4294967278,
+                        4294967278
+                      ],
+                      "referencedDeclaration": 4294967278,
+                      "src": "2583:7:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
+                        "typeString": "function (bool,string memory) pure"
+                      }
+                    },
+                    "id": 1196,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "2583:53:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 1197,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2583:53:8"
+                },
+                {
                   "assignments": [
-                    1155
+                    1199
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1155,
+                      "id": 1199,
                       "mutability": "mutable",
-                      "name": "sender",
-                      "nameLocation": "1613:6:8",
+                      "name": "minter",
+                      "nameLocation": "2654:6:8",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1165,
-                      "src": "1605:14:8",
+                      "scope": 1222,
+                      "src": "2646:14:8",
                       "stateVariable": false,
                       "storageLocation": "default",
                       "typeDescriptions": {
@@ -4899,10 +9659,10 @@
                         "typeString": "address"
                       },
                       "typeName": {
-                        "id": 1154,
+                        "id": 1198,
                         "name": "address",
                         "nodeType": "ElementaryTypeName",
-                        "src": "1605:7:8",
+                        "src": "2646:7:8",
                         "stateMutability": "nonpayable",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
@@ -4912,25 +9672,25 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1158,
+                  "id": 1202,
                   "initialValue": {
                     "arguments": [],
                     "expression": {
                       "argumentTypes": [],
-                      "id": 1156,
+                      "id": 1200,
                       "name": "_msgSender",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2952
+                        3136
                       ],
-                      "referencedDeclaration": 2952,
-                      "src": "1622:10:8",
+                      "referencedDeclaration": 3136,
+                      "src": "2663:10:8",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_view$__$returns$_t_address_$",
                         "typeString": "function () view returns (address)"
                       }
                     },
-                    "id": 1157,
+                    "id": 1201,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -4938,7 +9698,7 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1622:12:8",
+                    "src": "2663:12:8",
                     "tryCall": false,
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -4946,45 +9706,237 @@
                     }
                   },
                   "nodeType": "VariableDeclarationStatement",
-                  "src": "1605:29:8"
+                  "src": "2646:29:8"
+                },
+                {
+                  "assignments": [
+                    1204
+                  ],
+                  "declarations": [
+                    {
+                      "constant": false,
+                      "id": 1204,
+                      "mutability": "mutable",
+                      "name": "actualMinter",
+                      "nameLocation": "2693:12:8",
+                      "nodeType": "VariableDeclaration",
+                      "scope": 1222,
+                      "src": "2685:20:8",
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      },
+                      "typeName": {
+                        "id": 1203,
+                        "name": "address",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "2685:7:8",
+                        "stateMutability": "nonpayable",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      "visibility": "internal"
+                    }
+                  ],
+                  "id": 1208,
+                  "initialValue": {
+                    "arguments": [
+                      {
+                        "id": 1206,
+                        "name": "nftId",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 1186,
+                        "src": "2725:5:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      ],
+                      "id": 1205,
+                      "name": "_minterFromNftId",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 1321,
+                      "src": "2708:16:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_internal_pure$_t_uint256_$returns$_t_address_$",
+                        "typeString": "function (uint256) pure returns (address)"
+                      }
+                    },
+                    "id": 1207,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "2708:23:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "nodeType": "VariableDeclarationStatement",
+                  "src": "2685:46:8"
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "commonType": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        },
+                        "id": 1212,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "id": 1210,
+                          "name": "minter",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 1199,
+                          "src": "2749:6:8",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": "==",
+                        "rightExpression": {
+                          "id": 1211,
+                          "name": "actualMinter",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 1204,
+                          "src": "2759:12:8",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          }
+                        },
+                        "src": "2749:22:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      },
+                      {
+                        "hexValue": "4f6e6c79206d696e746572",
+                        "id": 1213,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "string",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "2773:13:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_stringliteral_578cb4a41adb75340d2cbfbdb0c6610ff4519d15e645cc9b4cc4c64336da99c6",
+                          "typeString": "literal_string \"Only minter\""
+                        },
+                        "value": "Only minter"
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        },
+                        {
+                          "typeIdentifier": "t_stringliteral_578cb4a41adb75340d2cbfbdb0c6610ff4519d15e645cc9b4cc4c64336da99c6",
+                          "typeString": "literal_string \"Only minter\""
+                        }
+                      ],
+                      "id": 1209,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        4294967278,
+                        4294967278
+                      ],
+                      "referencedDeclaration": 4294967278,
+                      "src": "2741:7:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
+                        "typeString": "function (bool,string memory) pure"
+                      }
+                    },
+                    "id": 1214,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "2741:46:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 1215,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2741:46:8"
                 },
                 {
                   "eventCall": {
                     "arguments": [
                       {
-                        "id": 1160,
-                        "name": "sender",
+                        "id": 1217,
+                        "name": "minter",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1155,
-                        "src": "1661:6:8",
+                        "referencedDeclaration": 1199,
+                        "src": "2820:6:8",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
                           "typeString": "address"
                         }
                       },
                       {
-                        "id": 1161,
+                        "id": 1218,
                         "name": "nftId",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1149,
-                        "src": "1669:5:8",
+                        "referencedDeclaration": 1186,
+                        "src": "2828:5:8",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
                         }
                       },
                       {
-                        "id": 1162,
-                        "name": "cid",
+                        "id": 1219,
+                        "name": "attachment",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1151,
-                        "src": "1676:3:8",
+                        "referencedDeclaration": 1188,
+                        "src": "2835:10:8",
                         "typeDescriptions": {
-                          "typeIdentifier": "t_bytes32",
-                          "typeString": "bytes32"
+                          "typeIdentifier": "t_bytes_calldata_ptr",
+                          "typeString": "bytes calldata"
                         }
                       }
                     ],
@@ -4999,22 +9951,22 @@
                           "typeString": "uint256"
                         },
                         {
-                          "typeIdentifier": "t_bytes32",
-                          "typeString": "bytes32"
+                          "typeIdentifier": "t_bytes_calldata_ptr",
+                          "typeString": "bytes calldata"
                         }
                       ],
-                      "id": 1159,
-                      "name": "AttachToNFT",
+                      "id": 1216,
+                      "name": "MinterAttachToNFT",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 1146,
-                      "src": "1649:11:8",
+                      "referencedDeclaration": 1165,
+                      "src": "2802:17:8",
                       "typeDescriptions": {
-                        "typeIdentifier": "t_function_event_nonpayable$_t_address_$_t_uint256_$_t_bytes32_$returns$__$",
-                        "typeString": "function (address,uint256,bytes32)"
+                        "typeIdentifier": "t_function_event_nonpayable$_t_address_$_t_uint256_$_t_bytes_memory_ptr_$returns$__$",
+                        "typeString": "function (address,uint256,bytes memory)"
                       }
                     },
-                    "id": 1163,
+                    "id": 1220,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -5022,46 +9974,46 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1649:31:8",
+                    "src": "2802:44:8",
                     "tryCall": false,
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 1164,
+                  "id": 1221,
                   "nodeType": "EmitStatement",
-                  "src": "1644:36:8"
+                  "src": "2797:49:8"
                 }
               ]
             },
             "documentation": {
-              "id": 1147,
+              "id": 1184,
               "nodeType": "StructuredDocumentation",
-              "src": "1293:237:8",
-              "text": "Attach an object identified by `cid` to the NFT type `nftId`.\n There is absolutely no validation. It is the responsibility of the reader of this event to decide\n who the sender is and what the object means."
+              "src": "2329:159:8",
+              "text": "Attach data `attachment` to the NFT type `nftId`, as the minter of this NFT type.\n This only works for NFT IDs in the Freeport format."
             },
-            "functionSelector": "ab278d19",
-            "id": 1166,
+            "functionSelector": "b85f8ca9",
+            "id": 1223,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
-            "name": "attachToNFT",
-            "nameLocation": "1544:11:8",
+            "name": "minterAttachToNFT",
+            "nameLocation": "2502:17:8",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1152,
+              "id": 1189,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1149,
+                  "id": 1186,
                   "mutability": "mutable",
                   "name": "nftId",
-                  "nameLocation": "1564:5:8",
+                  "nameLocation": "2528:5:8",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1166,
-                  "src": "1556:13:8",
+                  "scope": 1223,
+                  "src": "2520:13:8",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -5069,10 +10021,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1148,
+                    "id": 1185,
                     "name": "uint256",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1556:7:8",
+                    "src": "2520:7:8",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -5082,53 +10034,1371 @@
                 },
                 {
                   "constant": false,
-                  "id": 1151,
+                  "id": 1188,
                   "mutability": "mutable",
-                  "name": "cid",
-                  "nameLocation": "1579:3:8",
+                  "name": "attachment",
+                  "nameLocation": "2550:10:8",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1166,
-                  "src": "1571:11:8",
+                  "scope": 1223,
+                  "src": "2535:25:8",
                   "stateVariable": false,
-                  "storageLocation": "default",
+                  "storageLocation": "calldata",
                   "typeDescriptions": {
-                    "typeIdentifier": "t_bytes32",
-                    "typeString": "bytes32"
+                    "typeIdentifier": "t_bytes_calldata_ptr",
+                    "typeString": "bytes"
                   },
                   "typeName": {
-                    "id": 1150,
-                    "name": "bytes32",
+                    "id": 1187,
+                    "name": "bytes",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1571:7:8",
+                    "src": "2535:5:8",
                     "typeDescriptions": {
-                      "typeIdentifier": "t_bytes32",
-                      "typeString": "bytes32"
+                      "typeIdentifier": "t_bytes_storage_ptr",
+                      "typeString": "bytes"
                     }
                   },
                   "visibility": "internal"
                 }
               ],
-              "src": "1555:28:8"
+              "src": "2519:42:8"
             },
             "returnParameters": {
-              "id": 1153,
+              "id": 1190,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "1595:0:8"
+              "src": "2573:0:8"
             },
-            "scope": 1167,
-            "src": "1535:152:8",
+            "scope": 1322,
+            "src": "2493:360:8",
             "stateMutability": "nonpayable",
+            "virtual": false,
+            "visibility": "public"
+          },
+          {
+            "body": {
+              "id": 1264,
+              "nodeType": "Block",
+              "src": "3120:277:8",
+              "statements": [
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "commonType": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        },
+                        "id": 1234,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "id": 1232,
+                          "name": "nftId",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 1226,
+                          "src": "3138:5:8",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": "!=",
+                        "rightExpression": {
+                          "id": 1233,
+                          "name": "CURRENCY",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 1132,
+                          "src": "3147:8:8",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        "src": "3138:17:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      },
+                      {
+                        "hexValue": "30206973206e6f7420612076616c6964204e4654204944",
+                        "id": 1235,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "string",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "3157:25:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_stringliteral_ae13f91217f47fbcc2b0198f394de1f4adce3e41753550c13e2321d5da6b1b56",
+                          "typeString": "literal_string \"0 is not a valid NFT ID\""
+                        },
+                        "value": "0 is not a valid NFT ID"
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        },
+                        {
+                          "typeIdentifier": "t_stringliteral_ae13f91217f47fbcc2b0198f394de1f4adce3e41753550c13e2321d5da6b1b56",
+                          "typeString": "literal_string \"0 is not a valid NFT ID\""
+                        }
+                      ],
+                      "id": 1231,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        4294967278,
+                        4294967278
+                      ],
+                      "referencedDeclaration": 4294967278,
+                      "src": "3130:7:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
+                        "typeString": "function (bool,string memory) pure"
+                      }
+                    },
+                    "id": 1236,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "3130:53:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 1237,
+                  "nodeType": "ExpressionStatement",
+                  "src": "3130:53:8"
+                },
+                {
+                  "assignments": [
+                    1239
+                  ],
+                  "declarations": [
+                    {
+                      "constant": false,
+                      "id": 1239,
+                      "mutability": "mutable",
+                      "name": "owner",
+                      "nameLocation": "3201:5:8",
+                      "nodeType": "VariableDeclaration",
+                      "scope": 1264,
+                      "src": "3193:13:8",
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      },
+                      "typeName": {
+                        "id": 1238,
+                        "name": "address",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "3193:7:8",
+                        "stateMutability": "nonpayable",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      "visibility": "internal"
+                    }
+                  ],
+                  "id": 1242,
+                  "initialValue": {
+                    "arguments": [],
+                    "expression": {
+                      "argumentTypes": [],
+                      "id": 1240,
+                      "name": "_msgSender",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        3136
+                      ],
+                      "referencedDeclaration": 3136,
+                      "src": "3209:10:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_internal_view$__$returns$_t_address_$",
+                        "typeString": "function () view returns (address)"
+                      }
+                    },
+                    "id": 1241,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "3209:12:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "nodeType": "VariableDeclarationStatement",
+                  "src": "3193:28:8"
+                },
+                {
+                  "assignments": [
+                    1244
+                  ],
+                  "declarations": [
+                    {
+                      "constant": false,
+                      "id": 1244,
+                      "mutability": "mutable",
+                      "name": "balance",
+                      "nameLocation": "3239:7:8",
+                      "nodeType": "VariableDeclaration",
+                      "scope": 1264,
+                      "src": "3231:15:8",
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      },
+                      "typeName": {
+                        "id": 1243,
+                        "name": "uint256",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "3231:7:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      },
+                      "visibility": "internal"
+                    }
+                  ],
+                  "id": 1250,
+                  "initialValue": {
+                    "arguments": [
+                      {
+                        "id": 1247,
+                        "name": "owner",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 1239,
+                        "src": "3268:5:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      {
+                        "id": 1248,
+                        "name": "nftId",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 1226,
+                        "src": "3275:5:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        },
+                        {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      ],
+                      "expression": {
+                        "id": 1245,
+                        "name": "freeport",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 1128,
+                        "src": "3249:8:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_contract$_Freeport_$947",
+                          "typeString": "contract Freeport"
+                        }
+                      },
+                      "id": 1246,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "lValueRequested": false,
+                      "memberName": "balanceOf",
+                      "nodeType": "MemberAccess",
+                      "referencedDeclaration": 4103,
+                      "src": "3249:18:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_external_view$_t_address_$_t_uint256_$returns$_t_uint256_$",
+                        "typeString": "function (address,uint256) view external returns (uint256)"
+                      }
+                    },
+                    "id": 1249,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "3249:32:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "nodeType": "VariableDeclarationStatement",
+                  "src": "3231:50:8"
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "commonType": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        },
+                        "id": 1254,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "id": 1252,
+                          "name": "balance",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 1244,
+                          "src": "3299:7:8",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": ">",
+                        "rightExpression": {
+                          "hexValue": "30",
+                          "id": 1253,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "number",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "3309:1:8",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_rational_0_by_1",
+                            "typeString": "int_const 0"
+                          },
+                          "value": "0"
+                        },
+                        "src": "3299:11:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      },
+                      {
+                        "hexValue": "4f6e6c792063757272656e74206f776e6572",
+                        "id": 1255,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "string",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "3312:20:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_stringliteral_111b7c5d2b16684041cedd75c064e2306dd9ae18e93fc76a7b5be4886458a40b",
+                          "typeString": "literal_string \"Only current owner\""
+                        },
+                        "value": "Only current owner"
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        },
+                        {
+                          "typeIdentifier": "t_stringliteral_111b7c5d2b16684041cedd75c064e2306dd9ae18e93fc76a7b5be4886458a40b",
+                          "typeString": "literal_string \"Only current owner\""
+                        }
+                      ],
+                      "id": 1251,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        4294967278,
+                        4294967278
+                      ],
+                      "referencedDeclaration": 4294967278,
+                      "src": "3291:7:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
+                        "typeString": "function (bool,string memory) pure"
+                      }
+                    },
+                    "id": 1256,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "3291:42:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 1257,
+                  "nodeType": "ExpressionStatement",
+                  "src": "3291:42:8"
+                },
+                {
+                  "eventCall": {
+                    "arguments": [
+                      {
+                        "id": 1259,
+                        "name": "owner",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 1239,
+                        "src": "3365:5:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      {
+                        "id": 1260,
+                        "name": "nftId",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 1226,
+                        "src": "3372:5:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      },
+                      {
+                        "id": 1261,
+                        "name": "attachment",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 1228,
+                        "src": "3379:10:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bytes_calldata_ptr",
+                          "typeString": "bytes calldata"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        },
+                        {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        },
+                        {
+                          "typeIdentifier": "t_bytes_calldata_ptr",
+                          "typeString": "bytes calldata"
+                        }
+                      ],
+                      "id": 1258,
+                      "name": "OwnerAttachToNFT",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 1174,
+                      "src": "3348:16:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_event_nonpayable$_t_address_$_t_uint256_$_t_bytes_memory_ptr_$returns$__$",
+                        "typeString": "function (address,uint256,bytes memory)"
+                      }
+                    },
+                    "id": 1262,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "3348:42:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 1263,
+                  "nodeType": "EmitStatement",
+                  "src": "3343:47:8"
+                }
+              ]
+            },
+            "documentation": {
+              "id": 1224,
+              "nodeType": "StructuredDocumentation",
+              "src": "2859:177:8",
+              "text": "Attach data `attachment` to the NFT type `nftId`, as a current owner of an NFT of this type.\n This works for NFTs in the ERC-1155 or Freeport standards."
+            },
+            "functionSelector": "c0ba9f55",
+            "id": 1265,
+            "implemented": true,
+            "kind": "function",
+            "modifiers": [],
+            "name": "ownerAttachToNFT",
+            "nameLocation": "3050:16:8",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 1229,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 1226,
+                  "mutability": "mutable",
+                  "name": "nftId",
+                  "nameLocation": "3075:5:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1265,
+                  "src": "3067:13:8",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 1225,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3067:7:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 1228,
+                  "mutability": "mutable",
+                  "name": "attachment",
+                  "nameLocation": "3097:10:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1265,
+                  "src": "3082:25:8",
+                  "stateVariable": false,
+                  "storageLocation": "calldata",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes_calldata_ptr",
+                    "typeString": "bytes"
+                  },
+                  "typeName": {
+                    "id": 1227,
+                    "name": "bytes",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3082:5:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes_storage_ptr",
+                      "typeString": "bytes"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3066:42:8"
+            },
+            "returnParameters": {
+              "id": 1230,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "3120:0:8"
+            },
+            "scope": 1322,
+            "src": "3041:356:8",
+            "stateMutability": "nonpayable",
+            "virtual": false,
+            "visibility": "public"
+          },
+          {
+            "body": {
+              "id": 1291,
+              "nodeType": "Block",
+              "src": "3565:168:8",
+              "statements": [
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "commonType": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        },
+                        "id": 1276,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "id": 1274,
+                          "name": "nftId",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 1268,
+                          "src": "3583:5:8",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": "!=",
+                        "rightExpression": {
+                          "id": 1275,
+                          "name": "CURRENCY",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 1132,
+                          "src": "3592:8:8",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        },
+                        "src": "3583:17:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      },
+                      {
+                        "hexValue": "30206973206e6f7420612076616c6964204e4654204944",
+                        "id": 1277,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "string",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "3602:25:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_stringliteral_ae13f91217f47fbcc2b0198f394de1f4adce3e41753550c13e2321d5da6b1b56",
+                          "typeString": "literal_string \"0 is not a valid NFT ID\""
+                        },
+                        "value": "0 is not a valid NFT ID"
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        },
+                        {
+                          "typeIdentifier": "t_stringliteral_ae13f91217f47fbcc2b0198f394de1f4adce3e41753550c13e2321d5da6b1b56",
+                          "typeString": "literal_string \"0 is not a valid NFT ID\""
+                        }
+                      ],
+                      "id": 1273,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        4294967278,
+                        4294967278
+                      ],
+                      "referencedDeclaration": 4294967278,
+                      "src": "3575:7:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
+                        "typeString": "function (bool,string memory) pure"
+                      }
+                    },
+                    "id": 1278,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "3575:53:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 1279,
+                  "nodeType": "ExpressionStatement",
+                  "src": "3575:53:8"
+                },
+                {
+                  "assignments": [
+                    1281
+                  ],
+                  "declarations": [
+                    {
+                      "constant": false,
+                      "id": 1281,
+                      "mutability": "mutable",
+                      "name": "anonym",
+                      "nameLocation": "3646:6:8",
+                      "nodeType": "VariableDeclaration",
+                      "scope": 1291,
+                      "src": "3638:14:8",
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      },
+                      "typeName": {
+                        "id": 1280,
+                        "name": "address",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "3638:7:8",
+                        "stateMutability": "nonpayable",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      "visibility": "internal"
+                    }
+                  ],
+                  "id": 1284,
+                  "initialValue": {
+                    "arguments": [],
+                    "expression": {
+                      "argumentTypes": [],
+                      "id": 1282,
+                      "name": "_msgSender",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        3136
+                      ],
+                      "referencedDeclaration": 3136,
+                      "src": "3655:10:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_internal_view$__$returns$_t_address_$",
+                        "typeString": "function () view returns (address)"
+                      }
+                    },
+                    "id": 1283,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "3655:12:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "nodeType": "VariableDeclarationStatement",
+                  "src": "3638:29:8"
+                },
+                {
+                  "eventCall": {
+                    "arguments": [
+                      {
+                        "id": 1286,
+                        "name": "anonym",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 1281,
+                        "src": "3700:6:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      {
+                        "id": 1287,
+                        "name": "nftId",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 1268,
+                        "src": "3708:5:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      },
+                      {
+                        "id": 1288,
+                        "name": "attachment",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 1270,
+                        "src": "3715:10:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bytes_calldata_ptr",
+                          "typeString": "bytes calldata"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        },
+                        {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        },
+                        {
+                          "typeIdentifier": "t_bytes_calldata_ptr",
+                          "typeString": "bytes calldata"
+                        }
+                      ],
+                      "id": 1285,
+                      "name": "AnonymAttachToNFT",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 1183,
+                      "src": "3682:17:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_event_nonpayable$_t_address_$_t_uint256_$_t_bytes_memory_ptr_$returns$__$",
+                        "typeString": "function (address,uint256,bytes memory)"
+                      }
+                    },
+                    "id": 1289,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "3682:44:8",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 1290,
+                  "nodeType": "EmitStatement",
+                  "src": "3677:49:8"
+                }
+              ]
+            },
+            "documentation": {
+              "id": 1266,
+              "nodeType": "StructuredDocumentation",
+              "src": "3403:77:8",
+              "text": "Attach data `attachment` to the NFT type `nftId`, as any account."
+            },
+            "functionSelector": "f9715b8f",
+            "id": 1292,
+            "implemented": true,
+            "kind": "function",
+            "modifiers": [],
+            "name": "anonymAttachToNFT",
+            "nameLocation": "3494:17:8",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 1271,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 1268,
+                  "mutability": "mutable",
+                  "name": "nftId",
+                  "nameLocation": "3520:5:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1292,
+                  "src": "3512:13:8",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 1267,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3512:7:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 1270,
+                  "mutability": "mutable",
+                  "name": "attachment",
+                  "nameLocation": "3542:10:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1292,
+                  "src": "3527:25:8",
+                  "stateVariable": false,
+                  "storageLocation": "calldata",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes_calldata_ptr",
+                    "typeString": "bytes"
+                  },
+                  "typeName": {
+                    "id": 1269,
+                    "name": "bytes",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3527:5:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes_storage_ptr",
+                      "typeString": "bytes"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3511:42:8"
+            },
+            "returnParameters": {
+              "id": 1272,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "3565:0:8"
+            },
+            "scope": 1322,
+            "src": "3485:248:8",
+            "stateMutability": "nonpayable",
+            "virtual": false,
+            "visibility": "public"
+          },
+          {
+            "body": {
+              "id": 1320,
+              "nodeType": "Block",
+              "src": "4040:153:8",
+              "statements": [
+                {
+                  "expression": {
+                    "id": 1316,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "id": 1300,
+                      "name": "minter",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 1298,
+                      "src": "4050:6:8",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "arguments": [
+                        {
+                          "arguments": [
+                            {
+                              "commonType": {
+                                "typeIdentifier": "t_uint256",
+                                "typeString": "uint256"
+                              },
+                              "id": 1313,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "leftExpression": {
+                                "components": [
+                                  {
+                                    "commonType": {
+                                      "typeIdentifier": "t_uint256",
+                                      "typeString": "uint256"
+                                    },
+                                    "id": 1307,
+                                    "isConstant": false,
+                                    "isLValue": false,
+                                    "isPure": false,
+                                    "lValueRequested": false,
+                                    "leftExpression": {
+                                      "id": 1305,
+                                      "name": "id",
+                                      "nodeType": "Identifier",
+                                      "overloadedDeclarations": [],
+                                      "referencedDeclaration": 1295,
+                                      "src": "4076:2:8",
+                                      "typeDescriptions": {
+                                        "typeIdentifier": "t_uint256",
+                                        "typeString": "uint256"
+                                      }
+                                    },
+                                    "nodeType": "BinaryOperation",
+                                    "operator": "&",
+                                    "rightExpression": {
+                                      "hexValue": "307846464646464646464646464646464646464646464646464646464646464646464646464646464646303030303030303030303030303030303030303030303030",
+                                      "id": 1306,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "kind": "number",
+                                      "lValueRequested": false,
+                                      "nodeType": "Literal",
+                                      "src": "4081:66:8",
+                                      "typeDescriptions": {
+                                        "typeIdentifier": "t_rational_115792089237316195423570985008687907853269984665561335876943319670319585689600_by_1",
+                                        "typeString": "int_const 1157...(70 digits omitted)...9600"
+                                      },
+                                      "value": "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000000000000000"
+                                    },
+                                    "src": "4076:71:8",
+                                    "typeDescriptions": {
+                                      "typeIdentifier": "t_uint256",
+                                      "typeString": "uint256"
+                                    }
+                                  }
+                                ],
+                                "id": 1308,
+                                "isConstant": false,
+                                "isInlineArray": false,
+                                "isLValue": false,
+                                "isPure": false,
+                                "lValueRequested": false,
+                                "nodeType": "TupleExpression",
+                                "src": "4075:73:8",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_uint256",
+                                  "typeString": "uint256"
+                                }
+                              },
+                              "nodeType": "BinaryOperation",
+                              "operator": ">>",
+                              "rightExpression": {
+                                "components": [
+                                  {
+                                    "commonType": {
+                                      "typeIdentifier": "t_rational_96_by_1",
+                                      "typeString": "int_const 96"
+                                    },
+                                    "id": 1311,
+                                    "isConstant": false,
+                                    "isLValue": false,
+                                    "isPure": true,
+                                    "lValueRequested": false,
+                                    "leftExpression": {
+                                      "hexValue": "3332",
+                                      "id": 1309,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "kind": "number",
+                                      "lValueRequested": false,
+                                      "nodeType": "Literal",
+                                      "src": "4153:2:8",
+                                      "typeDescriptions": {
+                                        "typeIdentifier": "t_rational_32_by_1",
+                                        "typeString": "int_const 32"
+                                      },
+                                      "value": "32"
+                                    },
+                                    "nodeType": "BinaryOperation",
+                                    "operator": "+",
+                                    "rightExpression": {
+                                      "hexValue": "3634",
+                                      "id": 1310,
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": true,
+                                      "kind": "number",
+                                      "lValueRequested": false,
+                                      "nodeType": "Literal",
+                                      "src": "4158:2:8",
+                                      "typeDescriptions": {
+                                        "typeIdentifier": "t_rational_64_by_1",
+                                        "typeString": "int_const 64"
+                                      },
+                                      "value": "64"
+                                    },
+                                    "src": "4153:7:8",
+                                    "typeDescriptions": {
+                                      "typeIdentifier": "t_rational_96_by_1",
+                                      "typeString": "int_const 96"
+                                    }
+                                  }
+                                ],
+                                "id": 1312,
+                                "isConstant": false,
+                                "isInlineArray": false,
+                                "isLValue": false,
+                                "isPure": true,
+                                "lValueRequested": false,
+                                "nodeType": "TupleExpression",
+                                "src": "4152:9:8",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_rational_96_by_1",
+                                  "typeString": "int_const 96"
+                                }
+                              },
+                              "src": "4075:86:8",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_uint256",
+                                "typeString": "uint256"
+                              }
+                            }
+                          ],
+                          "expression": {
+                            "argumentTypes": [
+                              {
+                                "typeIdentifier": "t_uint256",
+                                "typeString": "uint256"
+                              }
+                            ],
+                            "id": 1304,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "lValueRequested": false,
+                            "nodeType": "ElementaryTypeNameExpression",
+                            "src": "4067:7:8",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_type$_t_uint160_$",
+                              "typeString": "type(uint160)"
+                            },
+                            "typeName": {
+                              "id": 1303,
+                              "name": "uint160",
+                              "nodeType": "ElementaryTypeName",
+                              "src": "4067:7:8",
+                              "typeDescriptions": {}
+                            }
+                          },
+                          "id": 1314,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "kind": "typeConversion",
+                          "lValueRequested": false,
+                          "names": [],
+                          "nodeType": "FunctionCall",
+                          "src": "4067:95:8",
+                          "tryCall": false,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint160",
+                            "typeString": "uint160"
+                          }
+                        }
+                      ],
+                      "expression": {
+                        "argumentTypes": [
+                          {
+                            "typeIdentifier": "t_uint160",
+                            "typeString": "uint160"
+                          }
+                        ],
+                        "id": 1302,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "lValueRequested": false,
+                        "nodeType": "ElementaryTypeNameExpression",
+                        "src": "4059:7:8",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_type$_t_address_$",
+                          "typeString": "type(address)"
+                        },
+                        "typeName": {
+                          "id": 1301,
+                          "name": "address",
+                          "nodeType": "ElementaryTypeName",
+                          "src": "4059:7:8",
+                          "typeDescriptions": {}
+                        }
+                      },
+                      "id": 1315,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "kind": "typeConversion",
+                      "lValueRequested": false,
+                      "names": [],
+                      "nodeType": "FunctionCall",
+                      "src": "4059:104:8",
+                      "tryCall": false,
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "src": "4050:113:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "id": 1317,
+                  "nodeType": "ExpressionStatement",
+                  "src": "4050:113:8"
+                },
+                {
+                  "expression": {
+                    "id": 1318,
+                    "name": "minter",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "referencedDeclaration": 1298,
+                    "src": "4180:6:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "functionReturnParameters": 1299,
+                  "id": 1319,
+                  "nodeType": "Return",
+                  "src": "4173:13:8"
+                }
+              ]
+            },
+            "documentation": {
+              "id": 1293,
+              "nodeType": "StructuredDocumentation",
+              "src": "3739:217:8",
+              "text": "Parse an NFT ID into its issuer, its supply, and an arbitrary nonce.\n This does not imply that the NFTs exist.\n This is specific to Freeport NFTs. See `freeportParts/Issuance.sol`"
+            },
+            "functionSelector": "d2e9277b",
+            "id": 1321,
+            "implemented": true,
+            "kind": "function",
+            "modifiers": [],
+            "name": "_minterFromNftId",
+            "nameLocation": "3970:16:8",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 1296,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 1295,
+                  "mutability": "mutable",
+                  "name": "id",
+                  "nameLocation": "3995:2:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1321,
+                  "src": "3987:10:8",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 1294,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3987:7:8",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3986:12:8"
+            },
+            "returnParameters": {
+              "id": 1299,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 1298,
+                  "mutability": "mutable",
+                  "name": "minter",
+                  "nameLocation": "4032:6:8",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1321,
+                  "src": "4024:14:8",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 1297,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "4024:7:8",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "4023:16:8"
+            },
+            "scope": 1322,
+            "src": "3961:232:8",
+            "stateMutability": "pure",
             "virtual": false,
             "visibility": "public"
           }
         ],
-        "scope": 1168,
-        "src": "537:1152:8",
+        "scope": 1323,
+        "src": "626:3569:8",
         "usedErrors": []
       }
     ],
-    "src": "0:1690:8"
+    "src": "0:4196:8"
   },
   "compiler": {
     "name": "solc",
@@ -5136,10 +11406,161 @@
   },
   "networks": {
     "137": {
-      "events": {},
+      "events": {
+        "0x4d1230ca9d634685a91b90e38709c77299e0c7591f7ac427d6cd88cf0f6114bf": {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "anonym",
+              "type": "address"
+            },
+            {
+              "indexed": true,
+              "internalType": "uint256",
+              "name": "nftId",
+              "type": "uint256"
+            },
+            {
+              "indexed": false,
+              "internalType": "bytes",
+              "name": "attachment",
+              "type": "bytes"
+            }
+          ],
+          "name": "AnonymAttachToNFT",
+          "type": "event"
+        },
+        "0x5dc5ea79bba163c4e3f9a2bb5350dbe8490685a9191001c5b4422b37f880d322": {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "minter",
+              "type": "address"
+            },
+            {
+              "indexed": true,
+              "internalType": "uint256",
+              "name": "nftId",
+              "type": "uint256"
+            },
+            {
+              "indexed": false,
+              "internalType": "bytes",
+              "name": "attachment",
+              "type": "bytes"
+            }
+          ],
+          "name": "MinterAttachToNFT",
+          "type": "event"
+        },
+        "0x70b7e5963956c4cbfbe79063259fc0996d3333c155342ae9110ca45e85995a55": {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "owner",
+              "type": "address"
+            },
+            {
+              "indexed": true,
+              "internalType": "uint256",
+              "name": "nftId",
+              "type": "uint256"
+            },
+            {
+              "indexed": false,
+              "internalType": "bytes",
+              "name": "attachment",
+              "type": "bytes"
+            }
+          ],
+          "name": "OwnerAttachToNFT",
+          "type": "event"
+        },
+        "0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff": {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "bytes32",
+              "name": "role",
+              "type": "bytes32"
+            },
+            {
+              "indexed": true,
+              "internalType": "bytes32",
+              "name": "previousAdminRole",
+              "type": "bytes32"
+            },
+            {
+              "indexed": true,
+              "internalType": "bytes32",
+              "name": "newAdminRole",
+              "type": "bytes32"
+            }
+          ],
+          "name": "RoleAdminChanged",
+          "type": "event"
+        },
+        "0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d": {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "bytes32",
+              "name": "role",
+              "type": "bytes32"
+            },
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            },
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "sender",
+              "type": "address"
+            }
+          ],
+          "name": "RoleGranted",
+          "type": "event"
+        },
+        "0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b": {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "bytes32",
+              "name": "role",
+              "type": "bytes32"
+            },
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            },
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "sender",
+              "type": "address"
+            }
+          ],
+          "name": "RoleRevoked",
+          "type": "event"
+        }
+      },
       "links": {},
-      "address": "0x147595af3de969a64f3Fb8A3ACC505325EBE1334",
-      "transactionHash": "0xcd6f97106891bd59bfdc0696238b7e1637c923dbd1a3c49f91110facd9c633c7"
+      "address": "0x5E376313fddBE3010F5d9fbC446C63d803590445",
+      "transactionHash": "0xc67180935f59f7a1d4c8f3b50253b2490a66efbb33335f4cfad2a3d046203a3e"
     },
     "80001": {
       "events": {
@@ -5242,15 +11663,96 @@
           ],
           "name": "RoleRevoked",
           "type": "event"
+        },
+        "0x4d1230ca9d634685a91b90e38709c77299e0c7591f7ac427d6cd88cf0f6114bf": {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "anonym",
+              "type": "address"
+            },
+            {
+              "indexed": true,
+              "internalType": "uint256",
+              "name": "nftId",
+              "type": "uint256"
+            },
+            {
+              "indexed": false,
+              "internalType": "bytes",
+              "name": "attachment",
+              "type": "bytes"
+            }
+          ],
+          "name": "AnonymAttachToNFT",
+          "type": "event"
+        },
+        "0x5dc5ea79bba163c4e3f9a2bb5350dbe8490685a9191001c5b4422b37f880d322": {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "minter",
+              "type": "address"
+            },
+            {
+              "indexed": true,
+              "internalType": "uint256",
+              "name": "nftId",
+              "type": "uint256"
+            },
+            {
+              "indexed": false,
+              "internalType": "bytes",
+              "name": "attachment",
+              "type": "bytes"
+            }
+          ],
+          "name": "MinterAttachToNFT",
+          "type": "event"
+        },
+        "0x70b7e5963956c4cbfbe79063259fc0996d3333c155342ae9110ca45e85995a55": {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "owner",
+              "type": "address"
+            },
+            {
+              "indexed": true,
+              "internalType": "uint256",
+              "name": "nftId",
+              "type": "uint256"
+            },
+            {
+              "indexed": false,
+              "internalType": "bytes",
+              "name": "attachment",
+              "type": "bytes"
+            }
+          ],
+          "name": "OwnerAttachToNFT",
+          "type": "event"
         }
       },
       "links": {},
-      "address": "0x2d16772036e7FA7D752b075b6b559A8bE57B8cCe",
-      "transactionHash": "0x7685461c4986299ad0d319785ed63eb83c3a1115e926cab77ef590e30c7b32ef"
+      "address": "0x64fe48A0555b3b822E5DAC8347DFD1FDc9A2E91D",
+      "transactionHash": "0x96c49a417bf6c43c17b6171f772255092f757a68264866a6c4e29f1eb808c2ff"
+    },
+    "1641562554735": {
+      "events": {},
+      "links": {},
+      "address": "0xffD2d7E75D6061cA00a160fCb1D12b385Ba40704",
+      "transactionHash": "0x7a501f282f273511b90f6d5d87578e324718a4d070c448ad8bba7762930e3fcf"
     }
   },
   "schemaVersion": "3.4.3",
-  "updatedAt": "2022-01-02T15:09:32.288Z",
+  "updatedAt": "2022-01-07T13:45:41.100Z",
   "networkType": "ethereum",
   "devdoc": {
     "kind": "dev",
@@ -5278,23 +11780,38 @@
   },
   "userdoc": {
     "events": {
-      "AttachToNFT(address,uint256,bytes32)": {
-        "notice": "The account `sender` wished to attach an object identified by `cid` to the NFT type `nftId`. There is absolutely no validation. It is the responsibility of the reader of this event to decide who the sender is and what the object means."
+      "AnonymAttachToNFT(address,uint256,bytes)": {
+        "notice": "The account `anonym` wished to attach data `attachment` to the NFT type `nftId`. There is absolutely no validation. It is the responsibility of the reader of this event to decide who the sender is and what the attachment means."
+      },
+      "MinterAttachToNFT(address,uint256,bytes)": {
+        "notice": "The account `minter` wished to attach data `attachment` to the NFT type `nftId`. The `minter` is the minter who created this NFT type, or may create it in the future if it does not exist."
+      },
+      "OwnerAttachToNFT(address,uint256,bytes)": {
+        "notice": "The account `owner` wished to attach data `attachment` to the NFT type `nftId`. The `owner` owned at least one NFT of this type at the time of the event."
       }
     },
     "kind": "user",
     "methods": {
-      "attachToNFT(uint256,bytes32)": {
-        "notice": "Attach an object identified by `cid` to the NFT type `nftId`. There is absolutely no validation. It is the responsibility of the reader of this event to decide who the sender is and what the object means."
+      "_minterFromNftId(uint256)": {
+        "notice": "Parse an NFT ID into its issuer, its supply, and an arbitrary nonce. This does not imply that the NFTs exist. This is specific to Freeport NFTs. See `freeportParts/Issuance.sol`"
+      },
+      "anonymAttachToNFT(uint256,bytes)": {
+        "notice": "Attach data `attachment` to the NFT type `nftId`, as any account."
       },
       "constructor": {
-        "notice": "Set which NFT contract to refer to."
+        "notice": "Set which NFT contract to refer to. The event `MinterAttachToNFT` is only supported for Freeport-compatible NFTs. The event `OwnerAttachToNFT` is supported for ERC-1155 NFTs, including Freeport."
       },
-      "nftContract()": {
-        "notice": "This attachment contract refers to the NFT contract in this variable. This is informative, there is no validation."
+      "freeport()": {
+        "notice": "This attachment contract refers to the NFT contract in this variable."
+      },
+      "minterAttachToNFT(uint256,bytes)": {
+        "notice": "Attach data `attachment` to the NFT type `nftId`, as the minter of this NFT type. This only works for NFT IDs in the Freeport format."
+      },
+      "ownerAttachToNFT(uint256,bytes)": {
+        "notice": "Attach data `attachment` to the NFT type `nftId`, as a current owner of an NFT of this type. This works for NFTs in the ERC-1155 or Freeport standards."
       }
     },
-    "notice": "The contract NFTAttachment allows users to attach objects to NFTs. Some application can listen for the events and interpret the objects in some way. Anyone can attach objects to any NFT. It is the responsibility of the app to interpret who the sender is and what the object means. An object is identified by CID, a.k.a. Content Identifier or IPFS file, of maximum 32 bytes. The content may be retrieved from Cere DDC or some other store.",
+    "notice": "The contract NFTAttachment allows users to attach objects to NFTs. Some application can listen for the events and interpret the objects in some way. There are three roles who can attach objects to an NFT: the minter, any current owner, or any anonymous account. A different event is emitted for each role. The attachment data is meant to identify an object hosted externally, such as a CID, a.k.a. Content Identifier, or a DDC URL. The content may be retrieved from Cere DDC or some other store.",
     "version": 1
   }
 }

--- a/contracts/NFTAttachment.sol
+++ b/contracts/NFTAttachment.sol
@@ -32,16 +32,16 @@ contract NFTAttachment is /* AccessControl, */ MetaTxContext {
     event AttachToNFT(
         address indexed sender,
         uint256 indexed nftId,
-        bytes32 cid);
+        bytes attachment);
 
     /** Attach an object identified by `cid` to the NFT type `nftId`.
      *
      * There is absolutely no validation. It is the responsibility of the reader of this event to decide
      * who the sender is and what the object means.
      */
-    function attachToNFT(uint256 nftId, bytes32 cid)
+    function attachToNFT(uint256 nftId, bytes calldata attachment)
     public {
         address sender = _msgSender();
-        emit AttachToNFT(sender, nftId, cid);
+        emit AttachToNFT(sender, nftId, attachment);
     }
 }

--- a/contracts/NFTAttachment.sol
+++ b/contracts/NFTAttachment.sol
@@ -1,47 +1,111 @@
 pragma solidity ^0.8.0;
 
 import "./freeportParts/MetaTxContext.sol";
+import "./Freeport.sol";
 
 /** The contract NFTAttachment allows users to attach objects to NFTs.
  * Some application can listen for the events and interpret the objects in some way.
  *
- * Anyone can attach objects to any NFT. It is the responsibility of the app to
- * interpret who the sender is and what the object means.
+ * There are three roles who can attach objects to an NFT:
+ * the minter, any current owner, or any anonymous account.
+ * A different event is emitted for each role.
  *
- * An object is identified by CID, a.k.a. Content Identifier or IPFS file, of maximum 32 bytes.
+ * The attachment data is meant to identify an object hosted externally,
+ * such as a CID, a.k.a. Content Identifier, or a DDC URL.
  * The content may be retrieved from Cere DDC or some other store.
  */
 contract NFTAttachment is /* AccessControl, */ MetaTxContext {
 
     /** This attachment contract refers to the NFT contract in this variable.
-     * This is informative, there is no validation.
      */
-    address public nftContract;
+    Freeport public freeport;
+
+    /** The token ID that represents the internal currency for all payments in Freeport. */
+    uint256 constant CURRENCY = 0;
 
     /** Set which NFT contract to refer to.
+     *
+     * The event `MinterAttachToNFT` is only supported for Freeport-compatible NFTs.
+     *
+     * The event `OwnerAttachToNFT` is supported for ERC-1155 NFTs, including Freeport.
      */
-    constructor(address _nftContract) {
-        nftContract = _nftContract;
+    constructor(Freeport _freeport) {
+        require(address(_freeport) != address(0));
+        freeport = _freeport;
     }
 
-    /** The account `sender` wished to attach an object identified by `cid` to the NFT type `nftId`.
+    /** The account `minter` wished to attach data `attachment` to the NFT type `nftId`.
      *
-     * There is absolutely no validation. It is the responsibility of the reader of this event to decide
-     * who the sender is and what the object means.
+     * The `minter` is the minter who created this NFT type, or may create it in the future if it does not exist.
      */
-    event AttachToNFT(
-        address indexed sender,
+    event MinterAttachToNFT(
+        address indexed minter,
         uint256 indexed nftId,
         bytes attachment);
 
-    /** Attach an object identified by `cid` to the NFT type `nftId`.
+    /** The account `owner` wished to attach data `attachment` to the NFT type `nftId`.
+     *
+     * The `owner` owned at least one NFT of this type at the time of the event.
+     */
+    event OwnerAttachToNFT(
+        address indexed owner,
+        uint256 indexed nftId,
+        bytes attachment);
+
+    /** The account `anonym` wished to attach data `attachment` to the NFT type `nftId`.
      *
      * There is absolutely no validation. It is the responsibility of the reader of this event to decide
-     * who the sender is and what the object means.
+     * who the sender is and what the attachment means.
      */
-    function attachToNFT(uint256 nftId, bytes calldata attachment)
+    event AnonymAttachToNFT(
+        address indexed anonym,
+        uint256 indexed nftId,
+        bytes attachment);
+
+    /** Attach data `attachment` to the NFT type `nftId`, as the minter of this NFT type.
+     *
+     * This only works for NFT IDs in the Freeport format.
+     */
+    function minterAttachToNFT(uint256 nftId, bytes calldata attachment)
     public {
-        address sender = _msgSender();
-        emit AttachToNFT(sender, nftId, attachment);
+        require(nftId != CURRENCY, "0 is not a valid NFT ID");
+        address minter = _msgSender();
+        address actualMinter = _minterFromNftId(nftId);
+        require(minter == actualMinter, "Only minter");
+        emit MinterAttachToNFT(minter, nftId, attachment);
+    }
+
+    /** Attach data `attachment` to the NFT type `nftId`, as a current owner of an NFT of this type.
+     *
+     * This works for NFTs in the ERC-1155 or Freeport standards.
+     */
+    function ownerAttachToNFT(uint256 nftId, bytes calldata attachment)
+    public {
+        require(nftId != CURRENCY, "0 is not a valid NFT ID");
+        address owner = _msgSender();
+        uint256 balance = freeport.balanceOf(owner, nftId);
+        require(balance > 0, "Only current owner");
+        emit OwnerAttachToNFT(owner, nftId, attachment);
+    }
+
+    /** Attach data `attachment` to the NFT type `nftId`, as any account.
+     */
+    function anonymAttachToNFT(uint256 nftId, bytes calldata attachment)
+    public {
+        require(nftId != CURRENCY, "0 is not a valid NFT ID");
+        address anonym = _msgSender();
+        emit AnonymAttachToNFT(anonym, nftId, attachment);
+    }
+
+    /** Parse an NFT ID into its issuer, its supply, and an arbitrary nonce.
+     *
+     * This does not imply that the NFTs exist.
+     *
+     * This is specific to Freeport NFTs. See `freeportParts/Issuance.sol`
+     */
+    function _minterFromNftId(uint256 id)
+    public pure returns (address minter) {
+        minter = address(uint160((id & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000000000000000) >> (32 + 64)));
+        return minter;
     }
 }

--- a/test/attachment_test.js
+++ b/test/attachment_test.js
@@ -10,21 +10,21 @@ contract("NFTAttachment", accounts => {
     it("sells an NFT by auction", async () => {
 
         const freeport = await Freeport.deployed();
-        const attachment = await NFTAttachment.deployed();
+        const nftAttachment = await NFTAttachment.deployed();
 
-        let gotFreeport = await attachment.nftContract.call();
+        let gotFreeport = await nftAttachment.nftContract.call();
         assert.equal(freeport.address, gotFreeport);
 
         let nftSupply = 10;
         let nftId = await freeport.issue.call(nftSupply, "0x", {from: sender});
 
-        let cid = "0x1122334455667788990011223344556677889900112233445566778899001122";
-        let receipt = await attachment.attachToNFT(nftId, cid);
+        let attachment = "0x11223344556677889900112233445566778899001122334455667788990011223344556677889900";
+        let receipt = await nftAttachment.attachToNFT(nftId, attachment);
 
         expectEvent(receipt, 'AttachToNFT', {
             sender,
             nftId,
-            cid,
+            attachment,
         });
     });
 });

--- a/test/attachment_test.js
+++ b/test/attachment_test.js
@@ -5,26 +5,73 @@ const {expectEvent, expectRevert, constants, time} = require('@openzeppelin/test
 const BN = require('bn.js');
 
 contract("NFTAttachment", accounts => {
-    const [sender] = accounts;
+    const [minter, owner, anonym] = accounts;
 
-    it("sells an NFT by auction", async () => {
+    let freeport, nftAttachment, nftId;
+    let nftSupply = 10;
+    let attachment = "0x11223344556677889900112233445566778899001122334455667788990011223344556677889900";
 
-        const freeport = await Freeport.deployed();
-        const nftAttachment = await NFTAttachment.deployed();
+    before(async () => {
+        freeport = await Freeport.deployed();
+        nftAttachment = await NFTAttachment.deployed();
+        nftId = await freeport.issue.call(nftSupply, "0x", {from: minter});
+        await freeport.issue(nftSupply, "0x", {from: minter});
+    });
 
-        let gotFreeport = await nftAttachment.nftContract.call();
+    it("NFTAttachment is configured", async () => {
+        let gotFreeport = await nftAttachment.freeport.call();
         assert.equal(freeport.address, gotFreeport);
+    });
 
-        let nftSupply = 10;
-        let nftId = await freeport.issue.call(nftSupply, "0x", {from: sender});
+    it("minter attaches data to an NFT", async () => {
+        await expectRevert(
+            nftAttachment.minterAttachToNFT(nftId, attachment, {from: anonym}),
+            "Only minter");
 
-        let attachment = "0x11223344556677889900112233445566778899001122334455667788990011223344556677889900";
-        let receipt = await nftAttachment.attachToNFT(nftId, attachment);
-
-        expectEvent(receipt, 'AttachToNFT', {
-            sender,
+        let receipt = await nftAttachment.minterAttachToNFT(nftId, attachment, {from: minter});
+        expectEvent(receipt, 'MinterAttachToNFT', {
+            minter,
             nftId,
             attachment,
         });
+    });
+
+    it("current owner attaches data to an NFT", async () => {
+        // owner does not have an NFT yet.
+        await expectRevert(
+            nftAttachment.ownerAttachToNFT(nftId, attachment, {from: owner}),
+            "Only current owner");
+
+        // Give 1 NFT to an owner.
+        await freeport.safeTransferFrom(minter, owner, nftId, 1, "0x");
+
+        let receipt = await nftAttachment.ownerAttachToNFT(nftId, attachment, {from: owner});
+        expectEvent(receipt, 'OwnerAttachToNFT', {
+            owner,
+            nftId,
+            attachment,
+        });
+    });
+
+    it("anonym attaches data to an NFT", async () => {
+        let receipt = await nftAttachment.anonymAttachToNFT(nftId, attachment, {from: anonym});
+        expectEvent(receipt, 'AnonymAttachToNFT', {
+            anonym,
+            nftId,
+            attachment,
+        });
+    });
+
+    it("cannot attach to the currency", async () => {
+        let invalidId = 0;
+        await expectRevert(
+            nftAttachment.minterAttachToNFT(invalidId, attachment, {from: minter}),
+            "0 is not a valid NFT ID");
+        await expectRevert(
+            nftAttachment.ownerAttachToNFT(invalidId, attachment, {from: owner}),
+            "0 is not a valid NFT ID");
+        await expectRevert(
+            nftAttachment.anonymAttachToNFT(invalidId, attachment, {from: anonym}),
+            "0 is not a valid NFT ID");
     });
 });


### PR DESCRIPTION
- **BREAKING**: Support for variable-sized attachment data (`bytes attachment`).
- **NEW**: A new event `MinterAttachToNFT` for attachments set by the NFT minter.
- **NEW**: A new event `OwnerAttachToNFT` for attachments set by a current owner of the NFT.
- **BREAKING**: Attachments by anonymous accounts are still supported, but the event was renamed to `AnonymAttachToNFT`.