### PR TITLE
Auction and Exchange work with erc20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Make SimpleAuction, SimpleExchange, and FiatGateway work with ERC20 directly.
 - Remove the function FiatGateway.buyCereFromUsd.
 
-### 1.1.0
+### v1.1.0
 
 - Fix a bug of incorrect royalty collection in auctions.
 - Fix a vulnerability that may allow a buyer to disrupt an auction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### Next release
 
+- Make SimpleAuction, SimpleExchange, and FiatGateway work with ERC20 directly.
+- Remove the function FiatGateway.buyCereFromUsd.
+
+### 1.1.0
+
 - Fix a bug of incorrect royalty collection in auctions.
 - Fix a vulnerability that may allow a buyer to disrupt an auction.
 - Additional public function transferFrom has been implemented in Freeport contract to support the above fixes.

--- a/contracts/SimpleAuction.sol
+++ b/contracts/SimpleAuction.sol
@@ -146,13 +146,13 @@ contract SimpleAuction is /* AccessControl, */ MetaTxContext, ERC1155HolderUpgra
         // Refund the previous buyer.
         address previousBuyer = bid.buyer;
         if (previousBuyer != address(0)) {
-            freeport.transferFrom(address(this), previousBuyer, CURRENCY, previousDeposit);
+            _returnDeposit(previousBuyer, previousDeposit);
         }
 
         // Take the new deposit from the new buyer.
         bid.buyer = buyer;
         bid.price = price;
-        freeport.transferFrom(buyer, address(this), CURRENCY, price);
+        _takeDeposit(buyer, price);
 
         emit BidOnAuction(seller, nftId, price, bid.closeTimeSec, buyer);
     }
@@ -178,7 +178,7 @@ contract SimpleAuction is /* AccessControl, */ MetaTxContext, ERC1155HolderUpgra
         if (buyer != address(0)) {
             // In case there was a buyer,
             // transfer the payment to the seller.
-            freeport.transferFrom(address(this), seller, CURRENCY, price);
+            _finalizePayment(seller, price);
 
             // Transfer the NFT to the buyer.
             freeport.transferFrom(address(this), buyer, nftId, 1);
@@ -193,5 +193,26 @@ contract SimpleAuction is /* AccessControl, */ MetaTxContext, ERC1155HolderUpgra
         }
 
         emit SettleAuction(seller, nftId, price, buyer);
+    }
+
+    function _takeDeposit(
+        address from,
+        uint amount
+    ) internal {
+        freeport.transferFrom(from, address(this), CURRENCY, amount);
+    }
+
+    function _returnDeposit(
+        address to,
+        uint amount
+    ) internal {
+        freeport.transferFrom(address(this), to, CURRENCY, amount);
+    }
+
+    function _finalizePayment(
+        address to,
+        uint amount
+    ) internal {
+        freeport.transferFrom(address(this), to, CURRENCY, amount);
     }
 }

--- a/contracts/SimpleAuction.sol
+++ b/contracts/SimpleAuction.sol
@@ -50,6 +50,7 @@ contract SimpleAuction is /* AccessControl, */ MetaTxContext, ERC1155HolderUpgra
     }
 
     /** Initialize this contract after version 2.0.0.
+     *
      * Allow deposit of USDC into Freeport.
      */
     function initialize_v2_0_0() public {
@@ -131,6 +132,7 @@ contract SimpleAuction is /* AccessControl, */ MetaTxContext, ERC1155HolderUpgra
         bid.closeTimeSec = closeTimeSec;
 
         // Take the NFT from the seller.
+        // Use the TRANSFER_OPERATOR role.
         freeport.transferFrom(seller, address(this), nftId, 1);
 
         emit StartAuction(seller, nftId, price, closeTimeSec);

--- a/contracts/freeportParts/ERC20Adapter.sol
+++ b/contracts/freeportParts/ERC20Adapter.sol
@@ -30,7 +30,7 @@ abstract contract ERC20Adapter is TransferOperator {
       Deposit currency from ERC20 into the internal currency.
       This requires payer to approve deposit.
      */
-    function deposit(uint256 amount) external {
+    function deposit(uint256 amount) public {
         address user = _msgSender();
         currencyContract.transferFrom(user, address(this), amount);
         _mint(user, CURRENCY, amount, "");

--- a/contracts/freeportParts/SimpleExchange.sol
+++ b/contracts/freeportParts/SimpleExchange.sol
@@ -84,8 +84,10 @@ abstract contract SimpleExchange is TransferFees {
         require(price != 0, "Not for sale");
         require(expectedPriceOrZero == 0 || expectedPriceOrZero == price, "Unexpected price");
 
-        // Pay. This verifies the intent of the payer.
         uint totalPrice = price * amount;
+        // Deposit ERC20 from payer. This verifies the intent of the payer.
+        deposit(totalPrice);
+        // Pay the seller. This verifies the intent of the payer.
         safeTransferFrom(payer, seller, CURRENCY, totalPrice, "");
 
         // Take a fee from the seller (really a cut of the above payment).

--- a/contracts/freeportParts/SimpleExchange.sol
+++ b/contracts/freeportParts/SimpleExchange.sol
@@ -68,7 +68,9 @@ abstract contract SimpleExchange is TransferFees {
      *
      * The offer must have been created beforehand by makeOffer.
      *
-     * The same authorization as safeTransferFrom apply to the buyer (sender or approved operator).
+     * The buyer receives the NFT.
+     * The sender pays the seller. The sender is not necessarily the same as buyer, see FiatGateway.
+     * The same authorization as safeTransferFrom apply to the caller (sender or approved operator).
      *
      * The parameter expectedPriceOrZero can be used to validate the price that the buyer expects to pay. This prevents
      * a race condition with makeOffer or setExchangeRate. Pass 0 to disable this validation and accept any current price.

--- a/contracts/freeportParts/SimpleExchange.sol
+++ b/contracts/freeportParts/SimpleExchange.sol
@@ -75,14 +75,16 @@ abstract contract SimpleExchange is TransferFees {
      */
     function takeOffer(address buyer, address seller, uint256 nftId, uint256 expectedPriceOrZero, uint256 amount)
     public {
+        address payer = _msgSender();
+
         // Check and update the amount offered.
         uint256 price = sellerNftPriceOffers[seller][nftId];
         require(price != 0, "Not for sale");
         require(expectedPriceOrZero == 0 || expectedPriceOrZero == price, "Unexpected price");
 
-        // Pay. This verifies the intent of the buyer.
+        // Pay. This verifies the intent of the payer.
         uint totalPrice = price * amount;
-        safeTransferFrom(buyer, seller, CURRENCY, totalPrice, "");
+        safeTransferFrom(payer, seller, CURRENCY, totalPrice, "");
 
         // Take a fee from the seller (really a cut of the above payment).
         uint totalFee = _captureFee(seller, nftId, price, amount);

--- a/contracts/freeportParts/SimpleExchange.sol
+++ b/contracts/freeportParts/SimpleExchange.sol
@@ -68,9 +68,11 @@ abstract contract SimpleExchange is TransferFees {
      *
      * The offer must have been created beforehand by makeOffer.
      *
+     * The sender pays ERC20. The sender is not necessarily the same as buyer, see FiatGateway.
+     *
+     * The seller receives internal currency (equivalent to the ERC20 payment, see the function withdraw).
+     *
      * The buyer receives the NFT.
-     * The sender pays the seller. The sender is not necessarily the same as buyer, see FiatGateway.
-     * The same authorization as safeTransferFrom apply to the caller (sender or approved operator).
      *
      * The parameter expectedPriceOrZero can be used to validate the price that the buyer expects to pay. This prevents
      * a race condition with makeOffer or setExchangeRate. Pass 0 to disable this validation and accept any current price.

--- a/migrations/10_upgrade_fiat_gateway.js
+++ b/migrations/10_upgrade_fiat_gateway.js
@@ -1,0 +1,21 @@
+const FiatGateway = artifacts.require("FiatGateway");
+const {upgradeProxy} = require('@openzeppelin/truffle-upgrades');
+const log = console.log;
+
+module.exports = async function (deployer, network, accounts) {
+    const gateway = await FiatGateway.deployed();
+    log("Operating on FiatGateway contract", gateway.address);
+
+    try {
+        const gateway2 = await upgradeProxy(gateway.address, FiatGateway, {deployer, kind: "uups"});
+        log("Upgraded", gateway2.address);
+
+        await gateway2.initialize_v2_0_0();
+        log("Done initialize_v2_0_0");
+    } catch (e) {
+        log("Error", e);
+        throw e;
+    }
+
+    log();
+};

--- a/migrations/3_deploy_fiat_gateway.js
+++ b/migrations/3_deploy_fiat_gateway.js
@@ -16,8 +16,9 @@ module.exports = async function (deployer, network, accounts) {
     const EXCHANGE_RATE_ORACLE = await gateway.EXCHANGE_RATE_ORACLE.call();
     const PAYMENT_SERVICE = await gateway.PAYMENT_SERVICE.call();
 
-    log("Give the permission to make transfers to FiatGateway.")
-    await freeport.grantRole(TRANSFER_OPERATOR, gateway.address);
+    // No longer necessary after v2.0.0
+    //log("Give the permission to make transfers to FiatGateway.")
+    //await freeport.grantRole(TRANSFER_OPERATOR, gateway.address);
 
     log("Operating on Admin account", admin);
     log("Give the permission to withdraw funds to Admin."); // In constructor.

--- a/migrations/4_deploy_simple_auction.js
+++ b/migrations/4_deploy_simple_auction.js
@@ -12,9 +12,8 @@ module.exports = async function (deployer, network, accounts) {
 
     const TRANSFER_OPERATOR = await freeport.TRANSFER_OPERATOR.call();
 
-    // No longer necessary after v2.0.0
-    //log("Give the permission to make transfers to SimpleAuction.")
-    //await freeport.grantRole(TRANSFER_OPERATOR, auction.address);
+    log("Give the permission to make transfers to SimpleAuction.")
+    await freeport.grantRole(TRANSFER_OPERATOR, auction.address);
 
     log();
 };

--- a/migrations/4_deploy_simple_auction.js
+++ b/migrations/4_deploy_simple_auction.js
@@ -12,8 +12,9 @@ module.exports = async function (deployer, network, accounts) {
 
     const TRANSFER_OPERATOR = await freeport.TRANSFER_OPERATOR.call();
 
-    log("Give the permission to make transfers to SimpleAuction.")
-    await freeport.grantRole(TRANSFER_OPERATOR, auction.address);
+    // No longer necessary after v2.0.0
+    //log("Give the permission to make transfers to SimpleAuction.")
+    //await freeport.grantRole(TRANSFER_OPERATOR, auction.address);
 
     log();
 };

--- a/migrations/9_upgrade_auction.js
+++ b/migrations/9_upgrade_auction.js
@@ -9,6 +9,9 @@ module.exports = async function (deployer, network, accounts) {
     try {
         const auction2 = await upgradeProxy(auction.address, SimpleAuction, {deployer, kind: "uups"});
         log("Upgraded", auction2.address);
+
+        await auction2.initialize_v2_0_0();
+        log("Done initialize_v2_0_0");
     } catch (e) {
         log("Error", e);
         throw e;

--- a/scripts/dev_setup.js
+++ b/scripts/dev_setup.js
@@ -10,7 +10,6 @@ module.exports = async function (done) {
 
     const CURRENCY = 0;
     let tenM = "10" + "000" + "000" + "000000"; // 10M with 6 decimals;
-    let fiveM = "5" + "000" + "000" + "000000"; // 5M with 6 decimals;
     let oneM = "1" + "000" + "000" + "000000"; // 1M with 6 decimals;
 
     let accounts = await web3.eth.getAccounts();
@@ -30,15 +29,11 @@ module.exports = async function (done) {
     const PAYMENT_SERVICE = await gateway.PAYMENT_SERVICE.call();
     await gateway.grantRole(PAYMENT_SERVICE, serviceAccount);
 
-    log("Mint and deposit some ERC20 to the admin account.");
-    await erc20.mint(admin, tenM);
-    await erc20.approve(freeport.address, tenM);
-    await freeport.deposit(tenM);
-
-    await freeport.safeTransferFrom(admin, gateway.address, CURRENCY, fiveM, "0x");
-    log("Sent 5M of currency to FiatGateway");
+    await erc20.mint(gateway.address, tenM);
+    log("Sent 10M of currency to FiatGateway");
 
     let devAccounts = [
+        admin,
         "0x6108E8aFFe0c51D4e2515A773aeF16b19ED6feB9", // e2e tests (Pavel)
         "0x6d2b28389d3153689c57909829dFCf6241d36388", // Evgeny
         "0x1Bf6FCa28253A1257e4B5B3440F7fbE0c59D1546", // Sergey
@@ -46,7 +41,7 @@ module.exports = async function (done) {
     ];
 
     for (let devAccount of devAccounts) {
-        await freeport.safeTransferFrom(admin, devAccount, CURRENCY, oneM, "0x");
+        await erc20.mint(devAccount, oneM);
         log("Sent 1M of currency to", devAccount);
     }
 

--- a/scripts/prod_topup_fiat.js
+++ b/scripts/prod_topup_fiat.js
@@ -28,19 +28,15 @@ module.exports = async function (done) {
 
         const usdcCheck = await freeport.currencyContract.call();
         console.assert(usdcCheck === usdc.address, "Unexpected USDC address");
-        let gatewayBalanceBefore = await freeport.balanceOf(gateway.address, CURRENCY);
+        let gatewayBalanceBefore = await erc20.balanceOf(gateway.address);
         log("Balance of FiatGateway contract: USDC", gatewayBalanceBefore.toNumber());
 
-        log("Amount: USDC", usdcAmount);
-        log("Approve Freeport to take a deposit");
-        await usdc.approve(freeport.address, usdcAmount);
-        log("Deposit into Freeport");
-        await freeport.deposit(usdcAmount);
-        log("Transfer to the FiatGateway contract");
-        await freeport.safeTransferFrom(admin, gateway.address, CURRENCY, usdcAmount, "0x");
+        log();
+        log("Transfer to the FiatGateway contract, amount: USDC", usdcAmount);
+        await usdc.transfer(gateway.address, usdcAmount);
 
         // Check after.
-        let gatewayBalanceAfter = await freeport.balanceOf(gateway.address, CURRENCY);
+        let gatewayBalanceAfter = await erc20.balanceOf(gateway.address);
         log("Balance of FiatGateway: USDC", gatewayBalanceAfter.toNumber());
 
         // ---- Top up MATIC ----

--- a/scripts/stage_setup.js
+++ b/scripts/stage_setup.js
@@ -10,7 +10,6 @@ module.exports = async function (done) {
 
     const CURRENCY = 0;
     let tenM = "10" + "000" + "000" + "000000"; // 10M with 6 decimals;
-    let fiveM = "5" + "000" + "000" + "000000"; // 9M with 6 decimals;
     let oneM = "1" + "000" + "000" + "000000"; // 1M with 6 decimals;
 
     let accounts = await web3.eth.getAccounts();
@@ -30,15 +29,11 @@ module.exports = async function (done) {
     const PAYMENT_SERVICE = await gateway.PAYMENT_SERVICE.call();
     await gateway.grantRole(PAYMENT_SERVICE, serviceAccount);
 
-    log("Mint and deposit some ERC20 to the admin account.");
-    await erc20.mint(admin, tenM);
-    await erc20.approve(freeport.address, tenM);
-    await freeport.deposit(tenM);
-
-    await freeport.safeTransferFrom(admin, gateway.address, CURRENCY, fiveM, "0x");
-    log("Sent 5M of currency to FiatGateway");
+    await erc20.mint(gateway.address, tenM);
+    log("Sent 10M of currency to FiatGateway");
 
     let devAccounts = [
+        admin,
         "0x6108E8aFFe0c51D4e2515A773aeF16b19ED6feB9", // e2e tests (Pavel)
         "0x6d2b28389d3153689c57909829dFCf6241d36388", // Evgeny
         "0x1Bf6FCa28253A1257e4B5B3440F7fbE0c59D1546", // Sergey
@@ -46,7 +41,7 @@ module.exports = async function (done) {
     ];
 
     for (let devAccount of devAccounts) {
-        await freeport.safeTransferFrom(admin, devAccount, CURRENCY, oneM, "0x");
+        await erc20.mint(devAccount, oneM);
         log("Sent 1M of currency to", devAccount);
     }
 

--- a/test/auction_test.js
+++ b/test/auction_test.js
@@ -64,9 +64,11 @@ contract("SimpleAuction", accounts => {
 
         // A helper function to check currency and NFT balances.
         let checkBalances = async (expected) => {
-            for (let [account, expectedCurrency, expectedNFTs] of expected) {
+            for (let [account, expectedERC20, expectedCurrency, expectedNFTs] of expected) {
+                let ercBalance = await erc20.balanceOf(account);
                 let currency = await freeport.balanceOf.call(account, CURRENCY);
                 let nfts = await freeport.balanceOf.call(account, nftId);
+                assert.equal(ercBalance, expectedERC20 * UNIT);
                 assert.equal(currency, expectedCurrency * UNIT);
                 assert.equal(nfts, expectedNFTs);
             }
@@ -100,6 +102,8 @@ contract("SimpleAuction", accounts => {
             [auction.address, 0, 1], // The contract took 1 NFT as deposit.
         ]);
 
+        await erc20.mint(buyerBob, 100 * UNIT);
+        await erc20.approve(auction.address, 1e9 * UNIT, {from: buyerBob});
         await auction.bidOnAuction(issuer, nftId, 100 * UNIT, {from: buyerBob});
 
         await checkBalances([

--- a/test/auction_test.js
+++ b/test/auction_test.js
@@ -32,12 +32,18 @@ contract("SimpleAuction", accounts => {
             await freeport.safeTransferFrom(deployer, account, CURRENCY, amount, "0x");
         };
 
-        return {freeport, erc20, deposit};
+        let withdraw = async (account) => {
+            let balance = await freeport.balanceOf(account, CURRENCY);
+            await freeport.withdraw(balance, {from: account});
+        };
+
+        return {freeport, erc20, deposit, withdraw};
     };
 
     let freeport;
     let erc20;
     let deposit;
+    let withdraw;
 
     before(async () => {
         let freeportOfMigrations = await Freeport.deployed();
@@ -45,6 +51,7 @@ contract("SimpleAuction", accounts => {
         freeport = x.freeport;
         erc20 = x.erc20;
         deposit = x.deposit;
+        withdraw = x.withdraw;
     });
 
 
@@ -55,8 +62,8 @@ contract("SimpleAuction", accounts => {
 
         // Give some initial tokens to the buyers.
         let someMoney = 1000;
-        await deposit(buyerBob, someMoney * UNIT);
-        await deposit(buyerBill, someMoney * UNIT);
+        await erc20.mint(buyerBob, someMoney * UNIT);
+        await erc20.mint(buyerBill, someMoney * UNIT);
 
         let nftSupply = 10;
         let nftId = await freeport.issue.call(nftSupply, "0x", {from: issuer});
@@ -64,12 +71,12 @@ contract("SimpleAuction", accounts => {
 
         // A helper function to check currency and NFT balances.
         let checkBalances = async (expected) => {
-            for (let [account, expectedERC20, expectedCurrency, expectedNFTs] of expected) {
+            for (let [account, expectedERC20, expectedNFTs] of expected) {
                 let ercBalance = await erc20.balanceOf(account);
                 let currency = await freeport.balanceOf.call(account, CURRENCY);
                 let nfts = await freeport.balanceOf.call(account, nftId);
                 assert.equal(ercBalance, expectedERC20 * UNIT);
-                assert.equal(currency, expectedCurrency * UNIT);
+                assert.equal(currency, 0);
                 assert.equal(nfts, expectedNFTs);
             }
         };
@@ -102,7 +109,6 @@ contract("SimpleAuction", accounts => {
             [auction.address, 0, 1], // The contract took 1 NFT as deposit.
         ]);
 
-        await erc20.mint(buyerBob, 100 * UNIT);
         await erc20.approve(auction.address, 1e9 * UNIT, {from: buyerBob});
         await auction.bidOnAuction(issuer, nftId, 100 * UNIT, {from: buyerBob});
 
@@ -115,6 +121,7 @@ contract("SimpleAuction", accounts => {
             auction.bidOnAuction(issuer, nftId, 109 * UNIT, {from: buyerBill}),
             "a new bid must be 10% greater than the current bid");
 
+        await erc20.approve(auction.address, 1e9 * UNIT, {from: buyerBill});
         await auction.bidOnAuction(issuer, nftId, 110 * UNIT, {from: buyerBill});
 
         await checkBalances([
@@ -138,6 +145,10 @@ contract("SimpleAuction", accounts => {
 
         // Settle the sale to buyer2 at 110 tokens.
         await auction.settleAuction(issuer, nftId);
+
+        // Issuer and benificiaries withdraw their earnings to ERC20.
+        await withdraw(issuer);
+        await withdraw(benificiary);
 
         // Check every balance after settlement.
         await checkBalances([

--- a/test/nft_test.js
+++ b/test/nft_test.js
@@ -40,12 +40,18 @@ contract("Freeport", accounts => {
             await freeport.safeTransferFrom(deployer, account, CURRENCY, amount, "0x");
         };
 
-        return {freeport, erc20, deposit};
+        let withdraw = async (account) => {
+            let balance = await freeport.balanceOf(account, CURRENCY);
+            await freeport.withdraw(balance, {from: account});
+        };
+
+        return {freeport, erc20, deposit, withdraw};
     };
 
     let freeport;
     let erc20;
     let deposit;
+    let withdraw;
 
     before(async () => {
         let freeportOfMigrations = await Freeport.deployed();
@@ -53,6 +59,7 @@ contract("Freeport", accounts => {
         freeport = x.freeport;
         erc20 = x.erc20;
         deposit = x.deposit;
+        withdraw = x.withdraw;
     });
 
 
@@ -188,12 +195,12 @@ contract("Freeport", accounts => {
     it("executes sales with variable royalties", async () => {
         log();
 
-        const {freeport, deposit} = await deploy();
+        const {freeport, erc20, deposit, withdraw} = await deploy();
 
         let pocketMoney = 1000 * UNIT;
-        await deposit(buyer, pocketMoney);
-        await deposit(buyer2, pocketMoney);
-        log("Deposit", pocketMoney / UNIT, "CERE from the bridge to account ’Buyer’");
+        await erc20.mint(buyer, pocketMoney);
+        await erc20.mint(buyer2, pocketMoney);
+        log("Deposit", pocketMoney / UNIT, "USDC to account ’Buyer’");
         log();
 
         // Other actors have no currency.
@@ -234,6 +241,8 @@ contract("Freeport", accounts => {
         await expectRevert.unspecified(
             freeport.takeOffer(buyer, issuer, nftId, price1 - 1, 1, {from: buyer}));
 
+        // Buy.
+        await erc20.approve(freeport.address, 1e9 * UNIT, {from: buyer});
         await freeport.takeOffer(buyer, issuer, nftId, price1, 1, {from: buyer});
 
         // Cannot take the offer again.
@@ -243,13 +252,20 @@ contract("Freeport", accounts => {
         // Secondary sale.
         let price2 = 300 * UNIT;
         await freeport.makeOffer(nftId, price2, {from: buyer});
+        // Buy.
+        await erc20.approve(freeport.address, 1e9 * UNIT, {from: buyer2});
         await freeport.takeOffer(buyer2, buyer, nftId, price2, 1, {from: buyer2});
 
         let partnerFee = price1 * 10 / 100; // Primary royalty on initial price.
         let someoneFee = price2 * 5 / 100; // Secondary royalty on a resale price.
 
+        await withdraw(issuer);
+        await withdraw(buyer);
+        await withdraw(partner);
+        await withdraw(someone);
+
         // Check everybody’s money after the deals.
-        for (let account of [
+        for (let [account, expectedERC20] of [
             // Issuer got the initial price and paid a primary fee.
             [issuer, price1 - partnerFee],
             // Buyer bought at the initial price, resold at another price, and paid a secondary fee.
@@ -261,8 +277,10 @@ contract("Freeport", accounts => {
             // Someone got a secondary fee.
             [someone, someoneFee],
         ]) {
-            let balance = await freeport.balanceOf.call(account[0], CURRENCY);
-            assert.equal(balance, account[1]);
+            let ercBalance = await erc20.balanceOf(account);
+            assert.equal(ercBalance, expectedERC20);
+            let internalBalance = await freeport.balanceOf.call(account, CURRENCY);
+            assert.equal(internalBalance, 0);
         }
     });
 
@@ -328,7 +346,7 @@ contract("Freeport", accounts => {
         await gateway.grantRole(PAYMENT_SERVICE, fiatService);
     };
 
-    it("buys CERE from USD", async () => {
+    it("cannot buy CERE from USD", async () => {
         const gateway = await FiatGateway.deployed();
         await setupFiatService(gateway);
 
@@ -354,41 +372,13 @@ contract("Freeport", accounts => {
         // Buy some CERE after a fiat payment.
         let priceCere = 200 * UNIT;
         let pricePennies = priceCere / cerePerPenny;
-        await gateway.buyCereFromUsd(
-            pricePennies,
-            buyer,
-            0,
-            {from: fiatService});
-
-        // Only the service account can do that.
-        await expectRevert.unspecified(gateway.buyCereFromUsd(
-            pricePennies,
-            buyer,
-            0,
-            {from: deployer}));
-
-        // Check all balances.
-        let balance = await freeport.balanceOf(gateway.address, CURRENCY);
-        assert.equal(balance, liquidities - priceCere);
-
-        balance = await freeport.balanceOf(buyer, CURRENCY);
-        assert.equal(balance, priceCere);
-
-        balance = await gateway.totalCereUnitsSent();
-        assert.equal(balance, priceCere);
-
-        balance = await gateway.totalPenniesReceived();
-        assert.equal(balance, pricePennies);
-
-        // Withdraw liquidities to the admin.
-        let initBalance = await freeport.balanceOf(deployer, CURRENCY);
-        await gateway.withdrawCurrency();
-
-        balance = await freeport.balanceOf(deployer, CURRENCY);
-        assert.equal(balance - initBalance, liquidities - priceCere);
-
-        // Send back the tokens to clean up.
-        await freeport.safeTransferFrom(buyer, deployer, CURRENCY, priceCere, "0x", {from: buyer});
+        await expectRevert(
+            gateway.buyCereFromUsd(
+                pricePennies,
+                buyer,
+                0,
+                {from: fiatService}),
+            "Discontinued");
     });
 
     it("buys an NFT from USD", async () => {
@@ -405,7 +395,7 @@ contract("Freeport", accounts => {
 
         // Top up FiatGateway with CERE.
         let liquidities = 1000 * UNIT;
-        await deposit(gateway.address, liquidities);
+        await erc20.mint(gateway.address, liquidities);
 
         // Set exchange rate.
         let cerePerPenny = 0.1 * UNIT;
@@ -433,7 +423,7 @@ contract("Freeport", accounts => {
             {from: deployer}));
 
         // Check all balances.
-        let balance = await freeport.balanceOf(gateway.address, CURRENCY);
+        let balance = await erc20.balanceOf(gateway.address);
         assert.equal(balance, liquidities - priceCere);
 
         balance = await freeport.balanceOf(issuer, CURRENCY);
@@ -448,9 +438,19 @@ contract("Freeport", accounts => {
         balance = await freeport.balanceOf(buyer, nftId);
         assert.equal(balance, 1);
 
+        // Issuer withdraws to ERC20.
+        await withdraw(issuer);
+
+        balance = await freeport.balanceOf(issuer, CURRENCY);
+        assert.equal(balance, 0);
+
+        balance = await erc20.balanceOf(issuer);
+        assert.equal(balance, priceCere);
+
         // Send back the tokens to clean up.
-        await gateway.withdrawCurrency();
-        await freeport.safeTransferFrom(issuer, deployer, CURRENCY, priceCere, "0x", {from: issuer});
+        balance = await gateway.withdrawERC20.call();
+        await gateway.withdrawERC20();
+        assert.equal(balance, liquidities - priceCere);
     });
 
     it("exchange ERC20 into internal currency", async () => {

--- a/test/nft_test.js
+++ b/test/nft_test.js
@@ -382,7 +382,7 @@ contract("Freeport", accounts => {
 
         // Withdraw liquidities to the admin.
         let initBalance = await freeport.balanceOf(deployer, CURRENCY);
-        await gateway.withdraw();
+        await gateway.withdrawCurrency();
 
         balance = await freeport.balanceOf(deployer, CURRENCY);
         assert.equal(balance - initBalance, liquidities - priceCere);
@@ -449,7 +449,7 @@ contract("Freeport", accounts => {
         assert.equal(balance, 1);
 
         // Send back the tokens to clean up.
-        await gateway.withdraw();
+        await gateway.withdrawCurrency();
         await freeport.safeTransferFrom(issuer, deployer, CURRENCY, priceCere, "0x", {from: issuer});
     });
 

--- a/test/nft_test.js
+++ b/test/nft_test.js
@@ -447,9 +447,11 @@ contract("Freeport", accounts => {
         balance = await erc20.balanceOf(issuer);
         assert.equal(balance, priceCere);
 
-        // Send back the tokens to clean up.
+        // Admin withdraws what remains in the gateway.
         balance = await gateway.withdrawERC20.call();
+        assert.equal(balance, liquidities - priceCere);
         await gateway.withdrawERC20();
+        balance = await erc20.balanceOf(accounts[0]);
         assert.equal(balance, liquidities - priceCere);
     });
 


### PR DESCRIPTION
The flow to buy an NFT before this PR was:
1. Approve Freeport in the USDC contract.
2. Deposit USDC into Freeport.
3. Buy with takeOffer or with bidOnAuction, using the deposit.

Now, it is:
1. Approve Freeport in the USDC contract. (same)
2. Buy with takeOffer, using USDC directly.

And:
1. Approve SimpleAuction in the USDC contract.
2. Buy with bidOnAuction, using USDC directly.

So the buyer does not need any deposit into Freeport at all. If he loses the auction, he gets back USDC directly.

The fiat gateway also works with USDC directly. The gateway works exactly like any other non-custodial buyer.

The sellers and royalty accounts still receive their revenues in Freeport. They must call withdraw to get back into USDC.

See also [FREEP-479](https://cerenetwork.atlassian.net/browse/FREEP-479)